### PR TITLE
Create config loader

### DIFF
--- a/.detekt/config.yaml
+++ b/.detekt/config.yaml
@@ -78,7 +78,7 @@ complexity:
     ignoreDataClasses: true
   MethodOverloading:
     active: true
-    threshold: 2
+    threshold: 3
   NamedArguments:
     active: true
     threshold: 3
@@ -448,7 +448,7 @@ potential-bugs:
   AvoidReferentialEquality:
     active: true
   CastNullableToNonNullableType:
-    active: true
+    active: false # This rule has poor support for platform types.
   CastToNullableType:
     active: true
   Deprecation:
@@ -666,7 +666,7 @@ style:
     active: true
   UnderscoresInNumericLiterals:
     active: true
-    acceptableLength: 3
+    acceptableLength: 4
     allowNonStandardGrouping: false
   UnnecessaryAbstractClass:
     active: false

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Kairo is an application framework built for Kotlin.
 
 ## Modules
 
+- [kairo-config](kairo-config/):
+  Home of `ConfigLoader`, which loads configs from YAML files,
+  with support for config extension and application.
 - [kairo-darb](kairo-darb/):
   Home of `DarbEncoder`, which encodes a list of booleans into a Dense-ish Albeit Readable Binary (DARB) string.
 - [kairo-dependency-injection](kairo-dependency-injection/):

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+guava = "33.2.1-jre" # https://github.com/google/guava/releases
 guice = "7.0.0" # https://github.com/google/guice/releases
 jackson = "2.17.2" # https://github.com/FasterXML/jackson-core/tags
 kotest = "5.9.1" # https://github.com/kotest/kotest/releases
@@ -8,6 +9,7 @@ log4j2 = "3.0.0-beta2" # https://github.com/apache/logging-log4j2/releases
 mockK = "1.13.12" # https://github.com/mockk/mockk/releases
 
 [libraries]
+guava = { module = "com.google.guava:guava", version.ref = "guava" }
 guice = { module = "com.google.inject:guice", version.ref = "guice" }
 jacksonCore = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
 jacksonDataformatYaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }

--- a/kairo-config/README.md
+++ b/kairo-config/README.md
@@ -29,6 +29,29 @@ Your YAML file **must** be in `config/*`.
 
 public data class MonolithServerConfig(
   val message: String,
+)
+```
+
+```yaml
+# src/main/resources/config/basic-config.yaml
+
+message: "Hello, World!"
+```
+
+```kotlin
+// src/main/kotlin/yourPackage/server/monolith/MonolithServer.kt
+
+ConfigLoader.load<MonolithServerConfig>("basic-config")
+```
+
+### Step 3: Try reading a complex config
+
+This is a "complex" config in the sense that it utilizes both _config extension_ and _config application_.
+The large number of config properties is needed to demonstrate by example how these features work.
+
+```kotlin
+public data class MonolithServerConfig(
+  val message: String,
   val name: String,
   val port: Int,
   val height: Sizes,
@@ -42,25 +65,6 @@ public data class MonolithServerConfig(
   )
 }
 ```
-
-```yaml
-# src/main/resources/config/basic-config.yaml
-
-message: "Hello, World!"
-name: "My config"
-port: 8080
-height: { min: 2, max: 10, average: 8 }
-width: { min: 4, max: 20, average: 16 }
-depth: { min: 6, max: 30, average: 24 }
-```
-
-```kotlin
-// src/main/kotlin/yourPackage/server/monolith/MonolithServer.kt
-
-ConfigLoader.load<MonolithServerConfig>("basic-config")
-```
-
-### Step 3: Try reading a complex config
 
 ```yaml
 # src/main/resources/config/base-config.yaml

--- a/kairo-config/README.md
+++ b/kairo-config/README.md
@@ -4,9 +4,9 @@ Home of `ConfigLoader`, which loads configs from YAML files,
 with support for config extension and application.
 
 - **Config extension:** Configs can extend other configs
-  by specifying "extends: other-config-name" as a top-level YAML property.
+  by specifying `extends: other-config-name` as a top-level YAML property.
 - **Config application:** Configs can apply other configs
-  by specifying "apply: [other-config-name-0, other-config-name-1] as a top-level YAML property
+  by specifying `apply: [other-config-name-0, other-config-name-1]` as a top-level YAML property
 
 ## Usage
 

--- a/kairo-config/README.md
+++ b/kairo-config/README.md
@@ -1,0 +1,107 @@
+# `kairo-config`
+
+Home of `ConfigLoader`, which loads configs from YAML files,
+with support for config extension and application.
+
+- **Config extension:** Configs can extend other configs
+  by specifying "extends: other-config-name" as a top-level YAML property.
+- **Config application:** Configs can apply other configs
+  by specifying "apply: [other-config-name-0, other-config-name-1] as a top-level YAML property
+
+## Usage
+
+### Step 1: Include the dependency
+
+```kotlin
+// build.gradle.kts
+
+dependencies {
+  api("kairo:kairo-config:0.3.0")
+}
+```
+
+### Step 2: Try reading a basic config
+
+Your YAML file **must** be in `config/*`.
+
+```kotlin
+// src/main/kotlin/yourPackage/server/monolith/MonolithServerConfig.kt
+
+public data class MonolithServerConfig(
+  val message: String,
+  val name: String,
+  val port: Int,
+  val height: Sizes,
+  val width: Sizes,
+  val depth: Sizes,
+) {
+  public data class Sizes(
+    val min: Int,
+    val max: Int,
+    val average: Int,
+  )
+}
+```
+
+```yaml
+# src/main/resources/config/basic-config.yaml
+
+message: "Hello, World!"
+name: "My config"
+port: 8080
+height: { min: 2, max: 10, average: 8 }
+width: { min: 4, max: 20, average: 16 }
+depth: { min: 6, max: 30, average: 24 }
+```
+
+```kotlin
+// src/main/kotlin/yourPackage/server/monolith/MonolithServer.kt
+
+ConfigLoader.load<MonolithServerConfig>("basic-config")
+```
+
+### Step 2: Try reading a complex config
+
+```yaml
+# src/main/resources/config/base-config.yaml
+
+extraRootProperty: "This breaks the config."
+name: "Base config"
+port: 3000
+height: { min: 2, max: 9, other: 9 }
+width: { min: 3, max: 19, average: 15 }
+```
+
+```yaml
+# src/main/resources/config/applied-config-0.yaml
+
+extraRootProperty: { remove: {} }
+message: "Applied config 0"
+name: { remove: {} }
+height:
+  merge: { max: 10, average: 8, other: { remove: {} } }
+depth:
+  replace: { min: 6, max: 30, average: 24 }
+```
+
+```yaml
+# src/main/resources/config/config-with-extension-and-application.yaml
+
+extends: base-config
+
+apply:
+  - applied-config-0
+
+message: "Hello, World!"
+name: "My config"
+port: 8080
+width:
+  replace: { min: 4, max: 20, average: 16 }
+
+```
+
+```kotlin
+// src/main/kotlin/yourPackage/server/monolith/MonolithServer.kt
+
+ConfigLoader.load<MonolithServerConfig>("config-with-extension-and-application")
+```

--- a/kairo-config/README.md
+++ b/kairo-config/README.md
@@ -60,7 +60,7 @@ depth: { min: 6, max: 30, average: 24 }
 ConfigLoader.load<MonolithServerConfig>("basic-config")
 ```
 
-### Step 2: Try reading a complex config
+### Step 3: Try reading a complex config
 
 ```yaml
 # src/main/resources/config/base-config.yaml

--- a/kairo-config/build.gradle.kts
+++ b/kairo-config/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+  id("kairo")
+  id("kairo-publish")
+}
+
+dependencies {
+  implementation(project(":kairo-logging"))
+  api(project(":kairo-protected-string")) // Exposed for clients.
+  implementation(project(":kairo-serialization"))
+  implementation(libs.guava) // For [Resources.getResource].
+
+  testImplementation(project(":kairo-logging"))
+  testImplementation(project(":testing"))
+}

--- a/kairo-config/src/main/kotlin/kairo/config/ConfigLoader.kt
+++ b/kairo-config/src/main/kotlin/kairo/config/ConfigLoader.kt
@@ -18,7 +18,7 @@ import kotlin.reflect.KClass
  * by specifying "extends: other-config-name" as a top-level YAML property.
  *
  * Config application: Configs can apply other configs
- * by specifying "apply: [other-config-name-0, other-config-name-1] as a top-level YAML property
+ * by specifying "apply: [other-config-name-0, other-config-name-1]" as a top-level YAML property
  */
 public object ConfigLoader {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Yaml).build()

--- a/kairo-config/src/main/kotlin/kairo/config/ConfigLoader.kt
+++ b/kairo-config/src/main/kotlin/kairo/config/ConfigLoader.kt
@@ -1,0 +1,85 @@
+package kairo.config
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.databind.node.ValueNode
+import com.fasterxml.jackson.module.kotlin.convertValue
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.google.common.io.Resources
+import kairo.serialization.ObjectMapperFactory
+import kairo.serialization.ObjectMapperFormat
+import kotlin.reflect.KClass
+
+/**
+ * Loads configs from YAML files, with support for config extension and application.
+ *
+ * Config extension: Configs can extend other configs
+ * by specifying "extends: other-config-name" as a top-level YAML property.
+ *
+ * Config application: Configs can apply other configs
+ * by specifying "apply: [other-config-name-0, other-config-name-1] as a top-level YAML property
+ */
+public object ConfigLoader {
+  private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Yaml).build()
+
+  public inline fun <reified C : Any> load(configName: String): C =
+    load(configName, C::class)
+
+  public fun <C : Any> load(configName: String, configKClass: KClass<C>): C {
+    val config = loadAsJson(configName)
+    return mapper.convertValue(config, configKClass.java)
+  }
+
+  private fun loadAsJson(configName: String): ObjectNode {
+    val config = simpleLoadAsJson(configName)
+    val extends = extractExtends(config)
+    val apply = extractApply(config)
+    var result = config
+    if (extends != null) {
+      result = simpleLoadAsJson(extends)
+    }
+    apply?.forEach { merge(result, loadAsJson(it)) }
+    if (extends != null) {
+      merge(result, config)
+    }
+    return result
+  }
+
+  private fun extractExtends(config: ObjectNode): String? {
+    val jsonNode = config.remove("extends") ?: return null
+    return mapper.convertValue<String>(jsonNode)
+  }
+
+  private fun extractApply(config: ObjectNode): List<String>? {
+    val jsonNode = config.remove("apply") ?: return null
+    return (jsonNode as ArrayNode).map { mapper.convertValue<String>(it) }
+  }
+
+  private fun simpleLoadAsJson(configName: String): ObjectNode {
+    val stream = Resources.getResource("config/$configName.yaml")
+    return mapper.readValue<ObjectNode>(stream)
+  }
+
+  private fun merge(extends: ObjectNode, config: ObjectNode) {
+    config.fields().forEach { (name, jsonNode) ->
+      when (jsonNode) {
+        is ValueNode -> mergeValueNode(extends, name, jsonNode)
+        is ObjectNode -> mergeObjectNode(extends, name, jsonNode)
+        else -> throw IllegalArgumentException("Unsupported JsonNode: $jsonNode.")
+      }
+    }
+  }
+
+  private fun mergeValueNode(extends: ObjectNode, name: String, jsonNode: ValueNode) {
+    extends.set<ObjectNode>(name, jsonNode)
+  }
+
+  private fun mergeObjectNode(extends: ObjectNode, name: String, jsonNode: ObjectNode) {
+    when (val mergeType = mapper.convertValue<MergeType>(jsonNode)) {
+      is MergeType.Merge -> merge(extends[name] as ObjectNode, mergeType.value)
+      is MergeType.Remove -> extends.remove(name)
+      is MergeType.Replace -> extends.set<ObjectNode>(name, mergeType.value)
+    }
+  }
+}

--- a/kairo-config/src/main/kotlin/kairo/config/MergeType.kt
+++ b/kairo-config/src/main/kotlin/kairo/config/MergeType.kt
@@ -1,0 +1,24 @@
+package kairo.config
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonValue
+import com.fasterxml.jackson.databind.node.ObjectNode
+
+/**
+ * Specifies how objects in configs should be merged, handled by [ConfigLoader].
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
+@JsonSubTypes(
+  JsonSubTypes.Type(MergeType.Merge::class, name = "merge"),
+  JsonSubTypes.Type(MergeType.Remove::class, name = "remove"),
+  JsonSubTypes.Type(MergeType.Replace::class, name = "replace"),
+)
+internal sealed class MergeType {
+  internal data class Merge @JsonCreator constructor(@JsonValue val value: ObjectNode) : MergeType()
+
+  internal data object Remove : MergeType()
+
+  internal data class Replace @JsonCreator constructor(@JsonValue val value: ObjectNode) : MergeType()
+}

--- a/kairo-config/src/test/kotlin/kairo/config/ConfigLoaderTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/ConfigLoaderTest.kt
@@ -1,0 +1,86 @@
+@file:Suppress("DEPRECATION")
+
+package kairo.config
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+internal class ConfigLoaderTest {
+  internal data class TestConfig(
+    val message: String,
+    val name: String,
+    val port: Int,
+    val height: Sizes,
+    val width: Sizes,
+    val depth: Sizes,
+  ) {
+    internal data class Sizes(
+      val min: Int,
+      val max: Int,
+      val average: Int,
+    )
+  }
+
+  private val testConfig: TestConfig =
+    TestConfig(
+      message = "Hello, World!",
+      name = "My config",
+      port = 8080,
+      height = TestConfig.Sizes(min = 2, max = 10, average = 8),
+      width = TestConfig.Sizes(min = 4, max = 20, average = 16),
+      depth = TestConfig.Sizes(min = 6, max = 30, average = 24),
+    )
+
+  @Test
+  fun `basic config`() {
+    ConfigLoader.load<TestConfig>("basic-config").shouldBe(testConfig)
+  }
+
+  @Test
+  fun `config with extra root property`() {
+    configLoadingShouldFail {
+      ConfigLoader.load<TestConfig>("config-with-extra-root-property")
+    }
+  }
+
+  @Test
+  fun `config with extra nested property`() {
+    configLoadingShouldFail {
+      ConfigLoader.load<TestConfig>("config-with-extra-nested-property")
+    }
+  }
+
+  @Test
+  fun `config with missing root property`() {
+    configLoadingShouldFail {
+      ConfigLoader.load<TestConfig>("config-with-missing-root-property")
+    }
+  }
+
+  @Test
+  fun `config with missing nested property`() {
+    configLoadingShouldFail {
+      ConfigLoader.load<TestConfig>("config-with-missing-nested-property")
+    }
+  }
+
+  @Test
+  fun `config with trivial extension`() {
+    ConfigLoader.load<TestConfig>("config-with-trivial-extension").shouldBe(testConfig)
+  }
+
+  @Test
+  fun `config with extension`() {
+    ConfigLoader.load<TestConfig>("config-with-extension").shouldBe(testConfig)
+  }
+
+  @Test
+  fun `config with application`() {
+    ConfigLoader.load<TestConfig>("config-with-application").shouldBe(testConfig)
+  }
+
+  @Test
+  fun `config with extension and application`() {
+    ConfigLoader.load<TestConfig>("config-with-application").shouldBe(testConfig)
+  }
+}

--- a/kairo-config/src/test/kotlin/kairo/config/configLoadingShouldFail.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/configLoadingShouldFail.kt
@@ -1,0 +1,10 @@
+package kairo.config
+
+import com.fasterxml.jackson.databind.JsonMappingException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.throwable.shouldHaveCauseInstanceOf
+
+internal fun configLoadingShouldFail(block: () -> Any?): IllegalArgumentException =
+  shouldThrow<IllegalArgumentException>(block).apply {
+    shouldHaveCauseInstanceOf<JsonMappingException>()
+  }

--- a/kairo-config/src/test/resources/config/applied-config-0.yaml
+++ b/kairo-config/src/test/resources/config/applied-config-0.yaml
@@ -1,0 +1,7 @@
+extraRootProperty: { remove: {} }
+message: "Applied config 0"
+name: { remove: {} }
+height:
+  merge: { max: 10, average: 8, other: { remove: {} } }
+depth:
+  replace: { min: 6, max: 30, average: 24 }

--- a/kairo-config/src/test/resources/config/applied-config-1.yaml
+++ b/kairo-config/src/test/resources/config/applied-config-1.yaml
@@ -1,0 +1,5 @@
+message: "Hello, World!"
+name: "My config"
+port: 8080
+width:
+  replace: { min: 4, max: 20, average: 16 }

--- a/kairo-config/src/test/resources/config/base-config.yaml
+++ b/kairo-config/src/test/resources/config/base-config.yaml
@@ -1,0 +1,5 @@
+extraRootProperty: "This breaks the config."
+name: "Base config"
+port: 3000
+height: { min: 2, max: 9, other: 9 }
+width: { min: 3, max: 19, average: 15 }

--- a/kairo-config/src/test/resources/config/basic-config.yaml
+++ b/kairo-config/src/test/resources/config/basic-config.yaml
@@ -1,0 +1,6 @@
+message: "Hello, World!"
+name: "My config"
+port: 8080
+height: { min: 2, max: 10, average: 8 }
+width: { min: 4, max: 20, average: 16 }
+depth: { min: 6, max: 30, average: 24 }

--- a/kairo-config/src/test/resources/config/config-with-application.yaml
+++ b/kairo-config/src/test/resources/config/config-with-application.yaml
@@ -1,0 +1,5 @@
+extends: base-config
+
+apply:
+  - applied-config-0
+  - applied-config-1

--- a/kairo-config/src/test/resources/config/config-with-extension-and-application.yaml
+++ b/kairo-config/src/test/resources/config/config-with-extension-and-application.yaml
@@ -1,0 +1,10 @@
+extends: base-config
+
+apply:
+  - applied-config-0
+
+message: "Hello, World!"
+name: "My config"
+port: 8080
+width:
+  replace: { min: 4, max: 20, average: 16 }

--- a/kairo-config/src/test/resources/config/config-with-extension.yaml
+++ b/kairo-config/src/test/resources/config/config-with-extension.yaml
@@ -1,0 +1,12 @@
+extends: base-config
+
+extraRootProperty: {remove: {} }
+message: "Hello, World!"
+name: "My config"
+port: 8080
+height:
+  merge: { max: 10, average: 8, other: { remove: {} } }
+width:
+  replace: { min: 4, max: 20, average: 16 }
+depth:
+  replace: { min: 6, max: 30, average: 24 }

--- a/kairo-config/src/test/resources/config/config-with-extra-nested-property.yaml
+++ b/kairo-config/src/test/resources/config/config-with-extra-nested-property.yaml
@@ -1,0 +1,6 @@
+message: "Hello, World!"
+name: "My config"
+port: 8080
+height: { min: 2, max: 10, average: 8, other: 9 }
+width: { min: 4, max: 20, average: 16 }
+depth: { min: 6, max: 30, average: 24 }

--- a/kairo-config/src/test/resources/config/config-with-extra-root-property.yaml
+++ b/kairo-config/src/test/resources/config/config-with-extra-root-property.yaml
@@ -1,0 +1,7 @@
+extraRootProperty: "This breaks the config."
+message: "Hello, World!"
+name: "My config"
+port: 8080
+height: { min: 2, max: 10, average: 8 }
+width: { min: 4, max: 20, average: 16 }
+depth: { min: 6, max: 30, average: 24 }

--- a/kairo-config/src/test/resources/config/config-with-missing-nested-property.yaml
+++ b/kairo-config/src/test/resources/config/config-with-missing-nested-property.yaml
@@ -1,0 +1,6 @@
+message: "Hello, World!"
+name: "My config"
+port: 8080
+height: { min: 2, max: 10 }
+width: { min: 4, max: 20, average: 16 }
+depth: { min: 6, max: 30, average: 24 }

--- a/kairo-config/src/test/resources/config/config-with-missing-root-property.yaml
+++ b/kairo-config/src/test/resources/config/config-with-missing-root-property.yaml
@@ -1,0 +1,5 @@
+message: "Hello, World!"
+port: 8080
+height: { min: 2, max: 10, average: 8 }
+width: { min: 4, max: 20, average: 16 }
+depth: { min: 6, max: 30, average: 24 }

--- a/kairo-config/src/test/resources/config/config-with-trivial-extension.yaml
+++ b/kairo-config/src/test/resources/config/config-with-trivial-extension.yaml
@@ -1,0 +1,1 @@
+extends: basic-config

--- a/kairo-darb/src/main/kotlin/kairo/darb/BooleanListEncoder.kt
+++ b/kairo-darb/src/main/kotlin/kairo/darb/BooleanListEncoder.kt
@@ -3,14 +3,14 @@ package kairo.darb
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 
+private val logger: KLogger = KotlinLogging.logger {}
+
 /**
  * Encodes a list of booleans into a string where each boolean from the list is represented by a 0 or a 1.
  * Also decodes; the inverse operation.
  * See the corresponding test for more spec.
  */
 internal object BooleanListEncoder {
-  private val logger: KLogger = KotlinLogging.logger {}
-
   fun encode(booleanList: List<Boolean>): String {
     val result = booleanList.joinToString("") { boolean -> if (boolean) "1" else "0" }
     logger.debug { "Encoded boolean list $booleanList to bit string $result." }

--- a/kairo-darb/src/main/kotlin/kairo/darb/DarbEncoder.kt
+++ b/kairo-darb/src/main/kotlin/kairo/darb/DarbEncoder.kt
@@ -3,6 +3,8 @@ package kairo.darb
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 
+private val logger: KLogger = KotlinLogging.logger {}
+
 /**
  * Encodes a list of booleans into a Dense-ish Albeit Readable Binary (DARB) string.
  * A DARB string contains 2 components, a prefix and a body, separated by a dot.
@@ -23,8 +25,6 @@ import io.github.oshai.kotlinlogging.KotlinLogging
  */
 public object DarbEncoder {
   private const val chunkSize: Int = 4 // Warning, changing this alone will break the code.
-
-  private val logger: KLogger = KotlinLogging.logger {}
 
   private val regex: Regex = Regex("[A-Fa-f0-9]*")
 
@@ -73,21 +73,17 @@ public object DarbEncoder {
   private fun getComponents(darb: String): Pair<Int, String> {
     // DARB always has 2 components separated by a dot, and no dots elsewhere in the syntax.
     val components = darb.split('.')
-    if (components.size != 2) throw IllegalArgumentException("DARB must have 2 components.")
+    require(components.size == 2) { "DARB must have 2 components." }
 
     // The first component is the size (positive).
     val size = components[0].toInt()
-    if (size < 0) throw IllegalArgumentException("DARB size cannot be negative.")
+    require(size >= 0) { "DARB size cannot be negative." }
 
     // The second component is the hex, the length of which must correlate with the size.
     val hex = components[1]
     // This math works due to integer rounding.
-    if (hex.length != (size + chunkSize - 1) / chunkSize) {
-      throw IllegalArgumentException("DARB hex length doesn't match size component.")
-    }
-    if (!this.regex.matches(hex)) {
-      throw IllegalArgumentException("Invalid DARB hex.")
-    }
+    require(hex.length == (size + chunkSize - 1) / chunkSize) { "DARB hex length doesn't match size component." }
+    require(regex.matches(hex)) { "Invalid DARB hex." }
     return Pair(size, hex)
   }
 

--- a/kairo-feature/build.gradle.kts
+++ b/kairo-feature/build.gradle.kts
@@ -6,6 +6,4 @@ plugins {
 dependencies {
   api(project(":kairo-dependency-injection"))
   implementation(project(":kairo-logging"))
-
-  testImplementation(project(":kairo-logging:testing"))
 }

--- a/kairo-feature/src/main/kotlin/kairo/feature/Feature.kt
+++ b/kairo-feature/src/main/kotlin/kairo/feature/Feature.kt
@@ -6,6 +6,8 @@ import com.google.inject.PrivateModule
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 
+private val logger: KLogger = KotlinLogging.logger {}
+
 /**
  * Features are the primary building block of Kairo applications.
  * Every piece of functionality,
@@ -15,8 +17,6 @@ import io.github.oshai.kotlinlogging.KotlinLogging
  * is represented by a Kairo Feature.
  */
 public abstract class Feature : PrivateModule() {
-  private val logger: KLogger = KotlinLogging.logger {}
-
   public abstract val name: String
 
   public abstract val priority: FeaturePriority

--- a/kairo-protected-string/README.md
+++ b/kairo-protected-string/README.md
@@ -32,7 +32,7 @@ dependencies {
 ### Step 2: Use protected strings
 
 ```kotlin
-// src/main/kotlin/yourPackage/YourFile.kt
+// src/main/kotlin/yourPackage/.../YourFile.kt
 
 val apiKey = ProtectedString("YOUR_API_KEY")
 

--- a/kairo-rest-feature/build.gradle.kts
+++ b/kairo-rest-feature/build.gradle.kts
@@ -8,6 +8,4 @@ dependencies {
   implementation(project(":kairo-logging"))
   implementation(libs.ktorServerCio)
   implementation(libs.ktorServerCore)
-
-  testImplementation(project(":kairo-logging:testing"))
 }

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestFeature.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestFeature.kt
@@ -11,11 +11,11 @@ import io.ktor.server.engine.embeddedServer
 import kairo.feature.Feature
 import kairo.feature.FeaturePriority
 
+private val logger: KLogger = KotlinLogging.logger {}
+
 public class RestFeature(
   private val config: RestConfig,
 ) : Feature() {
-  private val logger: KLogger = KotlinLogging.logger {}
-
   override val name: String = "REST"
 
   override val priority: FeaturePriority = FeaturePriority.Framework

--- a/kairo-serialization/README.md
+++ b/kairo-serialization/README.md
@@ -23,7 +23,7 @@ dependencies {
 ### Step 2: Create and use the object mapper
 
 ```kotlin
-// src/main/kotlin/yourPackage/YourFile.kt
+// src/main/kotlin/yourPackage/.../YourFile.kt
 
 val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 // Change ObjectMapperFormat.Json to use other formats, such as YAML.

--- a/kairo-serialization/build.gradle.kts
+++ b/kairo-serialization/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
   api(libs.jacksonCore)
   implementation(libs.jacksonDataformatYaml)
   implementation(libs.jacksonDatatypeJdk8)
-  api(libs.jacksonModuleKotlin)
+  api(libs.jacksonModuleKotlin) // There are some extension functions to expose.
 
   testImplementation(project(":kairo-logging:testing"))
   testImplementation(project(":testing"))

--- a/kairo-serialization/src/main/kotlin/kairo/serialization/ObjectMapperFactoryBuilder.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/ObjectMapperFactoryBuilder.kt
@@ -6,13 +6,13 @@ import com.fasterxml.jackson.databind.json.JsonMapper
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 
+private val logger: KLogger = KotlinLogging.logger {}
+
 public class ObjectMapperFactoryBuilder internal constructor(
   factory: JsonFactory,
   modules: List<Module>,
   block: ObjectMapperFactoryBuilder.() -> Unit,
 ) : JsonMapper.Builder(JsonMapper(factory)) {
-  private val logger: KLogger = KotlinLogging.logger {}
-
   /**
    * Unknown properties are prohibited by default by Jackson, and we respect that default here.
    * This is an appropriate choice for internal use.

--- a/kairo-server/src/main/kotlin/kairo/server/FeatureManager.kt
+++ b/kairo-server/src/main/kotlin/kairo/server/FeatureManager.kt
@@ -7,6 +7,8 @@ import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kairo.feature.Feature
 
+private val logger: KLogger = KotlinLogging.logger {}
+
 /**
  * A wrapper around a set of [Feature]s that helps [Server] manage their lifecycle.
  */
@@ -14,8 +16,6 @@ public class FeatureManager(
   private val features: Set<Feature>,
   private val config: FeatureManagerConfig,
 ) {
-  private val logger: KLogger = KotlinLogging.logger {}
-
   internal fun createInjector(): Injector =
     Guice.createInjector(Stage.PRODUCTION, features)
 

--- a/kairo-server/src/main/kotlin/kairo/server/Server.kt
+++ b/kairo-server/src/main/kotlin/kairo/server/Server.kt
@@ -7,12 +7,12 @@ import java.util.concurrent.locks.Lock
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
+private val logger: KLogger = KotlinLogging.logger {}
+
 /**
  * A Server is an application that runs a set of Features.
  */
 public abstract class Server {
-  private val logger: KLogger = KotlinLogging.logger {}
-
   protected abstract val featureManager: FeatureManager
 
   private val lock: Lock = ReentrantLock()

--- a/kairo-testing/README.md
+++ b/kairo-testing/README.md
@@ -21,7 +21,7 @@ dependencies {
 ### Step 2: Write a test
 
 ```kotlin
-// src/main/kotlin/yourPackage/YourTest.kt
+// src/main/kotlin/yourPackage/.../YourTest.kt
 
 internal class YourTest {
   @Test

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,6 @@
 rootProject.name = "kairo"
 
+include(":kairo-config")
 include(":kairo-darb")
 include(":kairo-dependency-injection")
 include(":kairo-feature")


### PR DESCRIPTION
### Summary

Part of #31.

The `ConfigLoader` loads configs from YAML files, with support for config extension and application. It will eventually handle `ProtectedString` instances too, but not yet.

There is a fair bit of boy scouting in this PR.

### Checklist

- [ ] Documentation (root README, Feature READMEs, KDoc, comments).
- [ ] Logging.
- [x] Tests.
