### PR TITLE
Allow using KAIRO_CONFIG environment variable for config name

### DIFF
--- a/kairo-config/README.md
+++ b/kairo-config/README.md
@@ -8,6 +8,9 @@ with support for config extension and application.
 - **Config application:** Configs can apply other configs
   by specifying `apply: [other-config-name-0, other-config-name-1]` as a top-level YAML property
 
+If no config name is provided to `ConfigLoader`,
+it will use the `KAIRO_CONFIG` envirnoment variable to identify the config name.
+
 ## Usage
 
 ### Step 1: Include the dependency

--- a/kairo-config/src/main/kotlin/kairo/config/ConfigLoader.kt
+++ b/kairo-config/src/main/kotlin/kairo/config/ConfigLoader.kt
@@ -41,6 +41,10 @@ public object ConfigLoader {
     return mapper.convertValue(config, configKClass.java)
   }
 
+  /**
+   * If a config name is provided, use it.
+   * Otherwise, fall back to the KAIRO_CONFIG environment variable.
+   */
   private fun getActualConfigName(configName: String?): String {
     if (configName != null) return configName
 


### PR DESCRIPTION
### Summary

Instead of requiring library users to specify the exact config name, it's convenient to default to using the `KAIRO_CONFIG` environment variable to identify the config name.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
