### PR TITLE
Add dependency injection utilities

### DIFF
--- a/.detekt/config.yaml
+++ b/.detekt/config.yaml
@@ -566,6 +566,7 @@ style:
     active: true
     # Keep these in sync with IntelliJ auto-import exclusions (codeInsightSettings.xml).
     imports:
+      - 'com.google.inject.TypeLiteral' # Use the Kotlin overload.
       - 'jakarta.validation.constraints.*'
       - 'javax.inject.*'
       - 'kotlin.time.Duration'
@@ -576,11 +577,12 @@ style:
     active: true
     methods:
       - 'com.fasterxml.jackson.core.JsonParser.readValueAs' # Use the Kotlin overload.
-      - 'com.google.inject.Binder.bind'
-      - 'com.google.inject.Key.get'
-      - 'com.google.inject.PrivateBinder.expose'
-      - 'com.google.inject.binder.LinkedBindingBuilder.to'
-      - 'com.google.inject.binder.LinkedBindingBuilder.toProvider(java.lang.Class)'
+      - 'com.google.inject.Binder.bind' # Use the Kotlin overload.
+      - 'com.google.inject.Injector.getInstance' # Use the Kotlin overload.
+      - 'com.google.inject.PrivateBinder.expose' # Use the Kotlin overload.
+      - 'com.google.inject.binder.LinkedBindingBuilder.to' # Use the Kotlin overload.
+      - 'com.google.inject.binder.LinkedBindingBuilder.toConstructor' # Use the Kotlin overload.
+      - 'com.google.inject.binder.LinkedBindingBuilder.toProvider' # Use the Kotlin overload.
       - 'java.time.format.DateTimeFormatter.ofPattern(java.lang.String)' # Use the overload that takes a Locale.
       - 'java.time.Instant.now()' # Use the overload that takes a Clock.
       - 'java.time.LocalDate.now()' # Use the overload that takes a Clock.
@@ -692,7 +694,7 @@ style:
   UntilInsteadOfRangeTo:
     active: true
   UnusedImports:
-    active: true
+    active: false # Overlaps with formatting>NoUnusedImports.
   UnusedParameter:
     active: true
   UnusedPrivateClass:

--- a/kairo-dependency-injection/src/main/kotlin/kairo/dependencyInjection/Binder.kt
+++ b/kairo-dependency-injection/src/main/kotlin/kairo/dependencyInjection/Binder.kt
@@ -1,0 +1,9 @@
+@file:Suppress("ForbiddenMethodCall")
+
+package kairo.dependencyInjection
+
+import com.google.inject.Binder
+import com.google.inject.binder.AnnotatedBindingBuilder
+
+public inline fun <reified T : Any> Binder.bind(): AnnotatedBindingBuilder<T> =
+  bind(T::class.java)

--- a/kairo-dependency-injection/src/main/kotlin/kairo/dependencyInjection/Injector.kt
+++ b/kairo-dependency-injection/src/main/kotlin/kairo/dependencyInjection/Injector.kt
@@ -1,0 +1,8 @@
+@file:Suppress("ForbiddenMethodCall")
+
+package kairo.dependencyInjection
+
+import com.google.inject.Injector
+
+public inline fun <reified T : Any> Injector.getInstance(): T =
+  getInstance(T::class.java)

--- a/kairo-dependency-injection/src/main/kotlin/kairo/dependencyInjection/LinkedBindingBuilder.kt
+++ b/kairo-dependency-injection/src/main/kotlin/kairo/dependencyInjection/LinkedBindingBuilder.kt
@@ -1,0 +1,14 @@
+@file:Suppress("ForbiddenMethodCall")
+
+package kairo.dependencyInjection
+
+import com.google.inject.Provider
+import com.google.inject.binder.LinkedBindingBuilder
+import com.google.inject.binder.ScopedBindingBuilder
+import kotlin.reflect.KClass
+
+public fun <T : Any> LinkedBindingBuilder<in T>.toClass(kClass: KClass<T>): ScopedBindingBuilder =
+  to(kClass.java)
+
+public fun <T : Any> LinkedBindingBuilder<T>.toProvider(kClass: KClass<out Provider<T>>): ScopedBindingBuilder =
+  toProvider(kClass.java)

--- a/kairo-dependency-injection/src/main/kotlin/kairo/dependencyInjection/PrivateBinder.kt
+++ b/kairo-dependency-injection/src/main/kotlin/kairo/dependencyInjection/PrivateBinder.kt
@@ -1,0 +1,9 @@
+@file:Suppress("ForbiddenMethodCall")
+
+package kairo.dependencyInjection
+
+import com.google.inject.PrivateBinder
+import com.google.inject.binder.AnnotatedElementBuilder
+
+public inline fun <reified T : Any> PrivateBinder.expose(): AnnotatedElementBuilder =
+  expose(T::class.java)

--- a/kairo-dependency-injection/src/main/kotlin/kairo/dependencyInjection/TypeLiteral.kt
+++ b/kairo-dependency-injection/src/main/kotlin/kairo/dependencyInjection/TypeLiteral.kt
@@ -1,0 +1,8 @@
+@file:Suppress("ForbiddenImport")
+
+package kairo.dependencyInjection
+
+import com.google.inject.TypeLiteral
+
+public inline fun <reified T> type(): TypeLiteral<T> =
+  object : TypeLiteral<T>() {}


### PR DESCRIPTION
### Summary

Guice is built using Java, which means its interfaces aren't very Kotlin-esque. This PR introduces some utilities that make Guice more natural to use from Kotlin.

It also updates some lint rules requiring these utilities to be used.

Finally, there's an unrelated Detekt change for imports.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
