### PR TITLE
Support time zone serialization

### DIFF
--- a/kairo-darb/README.md
+++ b/kairo-darb/README.md
@@ -14,7 +14,7 @@ In the example above, the first character "C" maps to 1100 in binary, which repr
 The second character "8" maps to 1000 in binary, which represents `true, false, false, false`.
 However, since there are only 5 booleans in the list (indicated by the prefix), we ignore the trailing booleans.
 
-**Examples**
+**Examples:**
 
 | DARB   | Boolean list                        |
 |--------|-------------------------------------|

--- a/kairo-serialization/README.md
+++ b/kairo-serialization/README.md
@@ -8,6 +8,23 @@ We don't use [kotlinx-serialization](https://github.com/Kotlin/kotlinx.serializa
 (although it is an excellent library)
 because of its limited support for polymorphism.
 
+**Type support:**
+
+- Primitive-like
+  - `Boolean`
+  - `Double`
+  - `Float`
+  - `Int`
+  - `Long`
+  - `String`
+- Java
+  - `Optional`
+  - `UUID`
+- Date/time
+  - `Instant`
+  - `LocalDate`
+  - `ZoneId`
+
 ## Usage
 
 ### Step 1: Include the dependency

--- a/kairo-serialization/src/main/kotlin/kairo/serialization/TimeModule.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/TimeModule.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.module.SimpleSerializers
 import com.fasterxml.jackson.databind.ser.Serializers
 import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneId
 
 /**
  * We don't use com.fasterxml.jackson.datatype:jackson-datatype-jsr310,
@@ -28,12 +29,14 @@ internal class TimeModule : SimpleModule() {
     SimpleSerializers().apply {
       addSerializer(Instant::class.javaObjectType, InstantSerializer())
       addSerializer(LocalDate::class.javaObjectType, LocalDateSerializer())
+      addSerializer(ZoneId::class.javaObjectType, ZoneIdSerializer())
     }
 
   private fun buildDeserializers(): Deserializers =
     SimpleDeserializers().apply {
       addDeserializer(Instant::class.javaObjectType, InstantDeserializer())
       addDeserializer(LocalDate::class.javaObjectType, LocalDateDeserializer())
+      addDeserializer(ZoneId::class.javaObjectType, ZoneIdDeserializer())
     }
 }
 

--- a/kairo-serialization/src/main/kotlin/kairo/serialization/ZoneIdDeserializer.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/ZoneIdDeserializer.kt
@@ -11,7 +11,7 @@ import java.time.ZoneOffset
  * We don't use com.fasterxml.jackson.datatype:jackson-datatype-jsr310,
  * and instead roll our own time module. See [TimeModule].
  *
- * This serializer intentionally only supports [ZoneRegion] and [ZoneOffset.UTC].
+ * This deserializer intentionally only supports [ZoneRegion] and [ZoneOffset.UTC].
  * Non-UTC [ZoneOffset]s are not supported.
  */
 internal class ZoneIdDeserializer : StdDeserializer<ZoneId>(ZoneId::class.java) {

--- a/kairo-serialization/src/main/kotlin/kairo/serialization/ZoneIdDeserializer.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/ZoneIdDeserializer.kt
@@ -10,6 +10,9 @@ import java.time.ZoneOffset
 /**
  * We don't use com.fasterxml.jackson.datatype:jackson-datatype-jsr310,
  * and instead roll our own time module. See [TimeModule].
+ *
+ * This serializer intentionally only supports [ZoneRegion] and [ZoneOffset.UTC].
+ * Non-UTC [ZoneOffset]s are not supported.
  */
 internal class ZoneIdDeserializer : StdDeserializer<ZoneId>(ZoneId::class.java) {
   override fun deserialize(p: JsonParser, ctxt: DeserializationContext): ZoneId {

--- a/kairo-serialization/src/main/kotlin/kairo/serialization/ZoneIdSerializer.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/ZoneIdSerializer.kt
@@ -1,0 +1,32 @@
+package kairo.serialization
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+/**
+ * We don't use com.fasterxml.jackson.datatype:jackson-datatype-jsr310,
+ * and instead roll our own time module. See [TimeModule].
+ *
+ * This serializer intentionally only supports [ZoneRegion] and [ZoneOffset.UTC].
+ * Non-UTC [ZoneOffset]s are not supported.
+ */
+internal class ZoneIdSerializer : StdSerializer<ZoneId>(ZoneId::class.java) {
+  override fun serialize(value: ZoneId, gen: JsonGenerator, provider: SerializerProvider) {
+    val string = convert(value)
+    gen.writeString(string)
+  }
+
+  private fun convert(timeZone: ZoneId): String {
+    if (timeZone is ZoneOffset) {
+      if (timeZone == ZoneOffset.UTC) return "UTC"
+      throw IllegalArgumentException("The only supported ZoneOffset is UTC.")
+    }
+    if (timeZone == ZoneId.of("UTC")) {
+      throw IllegalArgumentException("Prefer ZoneOffset.UTC to ZoneId.of(\"UTC\").")
+    }
+    return timeZone.id
+  }
+}

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/BooleanDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/BooleanDefaultObjectMapperTest.kt
@@ -42,35 +42,35 @@ internal class BooleanDefaultObjectMapperTest {
 
   @Test
   fun `deserialize, null`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": null }")
     }
   }
 
   @Test
   fun `deserialize, missing`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{}")
     }
   }
 
   @Test
   fun `deserialize, wrong type, int`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": 0 }")
     }
   }
 
   @Test
   fun `deserialize, wrong type, float`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": 1.0 }")
     }
   }
 
   @Test
   fun `deserialize, wrong type, string`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"false\" }")
     }
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/BooleanIsObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/BooleanIsObjectMapperTest.kt
@@ -46,14 +46,14 @@ internal class BooleanIsObjectMapperTest {
 
   @Test
   fun `deserialize, null`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"isValue\": null }")
     }
   }
 
   @Test
   fun `deserialize, missing`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{}")
     }
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/DoubleDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/DoubleDefaultObjectMapperTest.kt
@@ -42,14 +42,14 @@ internal class DoubleDefaultObjectMapperTest {
 
   @Test
   fun `deserialize, null`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": null }")
     }
   }
 
   @Test
   fun `deserialize, missing`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{}")
     }
   }
@@ -61,14 +61,14 @@ internal class DoubleDefaultObjectMapperTest {
 
   @Test
   fun `deserialize, wrong type, string`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"1.23\" }")
     }
   }
 
   @Test
   fun `deserialize, wrong type, boolean`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": true }")
     }
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/FloatDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/FloatDefaultObjectMapperTest.kt
@@ -42,14 +42,14 @@ internal class FloatDefaultObjectMapperTest {
 
   @Test
   fun `deserialize, null`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": null }")
     }
   }
 
   @Test
   fun `deserialize, missing`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{}")
     }
   }
@@ -61,14 +61,14 @@ internal class FloatDefaultObjectMapperTest {
 
   @Test
   fun `deserialize, wrong type, string`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"1.23\" }")
     }
   }
 
   @Test
   fun `deserialize, wrong type, boolean`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": true }")
     }
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/InstantDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/InstantDefaultObjectMapperTest.kt
@@ -47,133 +47,133 @@ internal class InstantDefaultObjectMapperTest {
 
   @Test
   fun `deserialize, null`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": null }")
     }
   }
 
   @Test
   fun `deserialize, missing`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{}")
     }
   }
 
   @Test
   fun `deserialize, missing leading zero from year`() {
-    deserializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\":\"1-02-03T19:44:32.123456789Z\" }")
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"1-02-03T19:44:32.123456789Z\" }")
     }
   }
 
   @Test
   fun `deserialize, missing leading zero from month`() {
-    deserializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\":\"2023-2-03T19:44:32.123456789Z\" }")
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"2023-2-03T19:44:32.123456789Z\" }")
     }
   }
 
   @Test
   fun `deserialize, missing leading zero from day`() {
-    deserializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\":\"2023-02-3T19:44:32.123456789Z\" }")
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"2023-02-3T19:44:32.123456789Z\" }")
     }
   }
 
   @Test
   fun `deserialize, missing leading zero from hour`() {
-    deserializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\":\"2023-02-03T9:44:32.123456789Z\" }")
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"2023-02-03T9:44:32.123456789Z\" }")
     }
   }
 
   @Test
   fun `deserialize, missing leading zero from minute`() {
-    deserializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\":\"2023-02-03T19:4:32.123456789Z\" }")
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"2023-02-03T19:4:32.123456789Z\" }")
     }
   }
 
   @Test
   fun `deserialize, missing leading zero from second`() {
-    deserializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\":\"2023-02-03T19:44:2.123456789Z\" }")
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"2023-02-03T19:44:2.123456789Z\" }")
     }
   }
 
   @Test
   fun `deserialize, nonexistent date (low month)`() {
-    deserializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\":\"2023-00-03T19:44:32.123456789Z\" }")
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"2023-00-03T19:44:32.123456789Z\" }")
     }
   }
 
   @Test
   fun `deserialize, nonexistent date (high month)`() {
-    deserializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\":\"2023-13-03T19:44:32.123456789Z\" }")
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"2023-13-03T19:44:32.123456789Z\" }")
     }
   }
 
   @Test
   fun `deserialize, nonexistent date (low day)`() {
-    deserializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\":\"2023-02-00T19:44:32.123456789Z\" }")
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"2023-02-00T19:44:32.123456789Z\" }")
     }
   }
 
   @Test
   fun `deserialize, nonexistent date (high day)`() {
-    deserializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\":\"2023-02-29T19:44:32.123456789Z\" }")
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"2023-02-29T19:44:32.123456789Z\" }")
     }
   }
 
   @Test
   fun `deserialize, nonexistent date (high hour)`() {
-    deserializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\":\"2023-02-03T24:44:32.123456789Z\" }")
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"2023-02-03T24:44:32.123456789Z\" }")
     }
   }
 
   @Test
   fun `deserialize, nonexistent date (high minute)`() {
-    deserializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\":\"2023-02-03T19:60:32.123456789Z\" }")
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"2023-02-03T19:60:32.123456789Z\" }")
     }
   }
 
   @Test
   fun `deserialize, nonexistent date (high second)`() {
-    deserializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\":\"2023-02-03T19:44:60.123456789Z\" }")
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"2023-02-03T19:44:60.123456789Z\" }")
     }
   }
 
   @Test
   fun `deserialize, too much precision`() {
-    deserializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\":\"2023-02-03T19:44:32.1234567890Z\" }")
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"2023-02-03T19:44:32.1234567890Z\" }")
     }
   }
 
   @Test
   fun `deserialize, no time zone`() {
-    deserializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\":\"2023-02-03T19:44:32.123456789\" }")
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"2023-02-03T19:44:32.123456789\" }")
     }
   }
 
   @Test
   fun `deserialize, non-UTC`() {
-    deserializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\":\"2023-02-03T19:44:32.123456789-07:00[America/Edmonton]\" }")
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"2023-02-03T19:44:32.123456789-07:00[America/Edmonton]\" }")
     }
   }
 
   @Test
   fun `deserialize, wrong type, number`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": 1699904672123 }")
     }
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/IntDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/IntDefaultObjectMapperTest.kt
@@ -42,35 +42,35 @@ internal class IntDefaultObjectMapperTest {
 
   @Test
   fun `deserialize, null`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": null }")
     }
   }
 
   @Test
   fun `deserialize, missing`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{}")
     }
   }
 
   @Test
   fun `deserialize, wrong type, float`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": 1.23 }")
     }
   }
 
   @Test
   fun `deserialize, wrong type, string`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"42\" }")
     }
   }
 
   @Test
   fun `deserialize, wrong type, boolean`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": true }")
     }
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/LocalDateDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/LocalDateDefaultObjectMapperTest.kt
@@ -47,70 +47,70 @@ internal class LocalDateDefaultObjectMapperTest {
 
   @Test
   fun `deserialize, null`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": null }")
     }
   }
 
   @Test
   fun `deserialize, missing`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{}")
     }
   }
 
   @Test
   fun `deserialize, missing leading zero from year`() {
-    deserializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\":\"1-02-03\" }")
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"1-02-03\" }")
     }
   }
 
   @Test
   fun `deserialize, missing leading zero from month`() {
-    deserializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\":\"2023-2-03\" }")
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"2023-2-03\" }")
     }
   }
 
   @Test
   fun `deserialize, missing leading zero from day`() {
-    deserializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\":\"2023-02-3\" }")
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"2023-02-3\" }")
     }
   }
 
   @Test
   fun `deserialize, nonexistent date (low month)`() {
-    deserializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\":\"2023-00-03\" }")
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"2023-00-03\" }")
     }
   }
 
   @Test
   fun `deserialize, nonexistent date (high month)`() {
-    deserializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\":\"2023-13-03\" }")
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"2023-13-03\" }")
     }
   }
 
   @Test
   fun `deserialize, nonexistent date (low day)`() {
-    deserializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\":\"2023-02-00\" }")
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"2023-02-00\" }")
     }
   }
 
   @Test
   fun `deserialize, nonexistent date (high day)`() {
-    deserializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\":\"2023-02-29\" }")
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"2023-02-29\" }")
     }
   }
 
   @Test
   fun `deserialize, wrong type, number`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": 20231113 }")
     }
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/LongDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/LongDefaultObjectMapperTest.kt
@@ -42,35 +42,35 @@ internal class LongDefaultObjectMapperTest {
 
   @Test
   fun `deserialize, null`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": null }")
     }
   }
 
   @Test
   fun `deserialize, missing`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{}")
     }
   }
 
   @Test
   fun `deserialize, wrong type, float`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": 1.23 }")
     }
   }
 
   @Test
   fun `deserialize, wrong type, string`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"42\" }")
     }
   }
 
   @Test
   fun `deserialize, wrong type, boolean`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": true }")
     }
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/OptionalDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/OptionalDefaultObjectMapperTest.kt
@@ -49,28 +49,28 @@ internal class OptionalDefaultObjectMapperTest {
 
   @Test
   fun `deserialize, missing`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{}")
     }
   }
 
   @Test
   fun `deserialize, wrong type, float`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": 1.23 }")
     }
   }
 
   @Test
   fun `deserialize, wrong type, string`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"42\" }")
     }
   }
 
   @Test
   fun `deserialize, wrong type, boolean`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": true }")
     }
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/StringDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/StringDefaultObjectMapperTest.kt
@@ -42,35 +42,35 @@ internal class StringDefaultObjectMapperTest {
 
   @Test
   fun `deserialize, null`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": null }")
     }
   }
 
   @Test
   fun `deserialize, missing`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{}")
     }
   }
 
   @Test
   fun `deserialize, wrong type, int`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": 1 }")
     }
   }
 
   @Test
   fun `deserialize, wrong type, float`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": 0.0 }")
     }
   }
 
   @Test
   fun `deserialize, wrong type, boolean`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": true }")
     }
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/UnknownPropertyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/UnknownPropertyObjectMapperTest.kt
@@ -16,7 +16,7 @@ internal class UnknownPropertyObjectMapperTest {
   @Test
   fun `unknown properties disallowed (default)`() {
     val mapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"foo\": \"bar\", \"baz\": \"qux\" }")
     }
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/UuidDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/UuidDefaultObjectMapperTest.kt
@@ -35,63 +35,63 @@ internal class UuidDefaultObjectMapperTest {
 
   @Test
   fun `deserialize, null`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": null }")
     }
   }
 
   @Test
   fun `deserialize, missing`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{}")
     }
   }
 
   @Test
   fun `deserialize, too short`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"3ec0a853-dae3-4ee1-abe2-0b9c7dee45f\" }")
     }
   }
 
   @Test
   fun `deserialize, too long`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"3ec0a853-dae3-4ee1-abe2-0b9c7dee45f88\" }")
     }
   }
 
   @Test
   fun `deserialize, missing dashes`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"3ec0a853dae34ee1abe20b9c7dee45f8\" }")
     }
   }
 
   @Test
   fun `deserialize, invalid character`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"3ec0a853-dae3-4ee1-abe2-0b9c7dee45fg\" }")
     }
   }
 
   @Test
   fun `deserialize, wrong type, int`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": 42 }")
     }
   }
 
   @Test
   fun `deserialize, wrong type, float`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": 1.23 }")
     }
   }
 
   @Test
   fun `deserialize, wrong type, boolean`() {
-    deserializationShouldFail {
+    serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": true }")
     }
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/ZoneIdDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/ZoneIdDefaultObjectMapperTest.kt
@@ -8,9 +8,9 @@ import java.time.ZoneOffset
 import org.junit.jupiter.api.Test
 
 /**
- * This test is intended to test behaviour strictly related to zone ID serialization/deserialization.
+ * This test is intended to test behaviour strictly related to time zone serialization/deserialization.
  * Therefore, some test cases (such as unknown properties, pretty printing) are not included
- * since they are not strictly related to zone IDs.
+ * since they are not strictly related to time zones.
  */
 internal class ZoneIdDefaultObjectMapperTest {
   /**

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/ZoneIdDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/ZoneIdDefaultObjectMapperTest.kt
@@ -1,0 +1,90 @@
+package kairo.serialization
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.kotest.matchers.shouldBe
+import java.time.ZoneId
+import java.time.ZoneOffset
+import org.junit.jupiter.api.Test
+
+/**
+ * This test is intended to test behaviour strictly related to zone ID serialization/deserialization.
+ * Therefore, some test cases (such as unknown properties, pretty printing) are not included
+ * since they are not strictly related to zone IDs.
+ */
+internal class ZoneIdDefaultObjectMapperTest {
+  /**
+   * This test is specifically for non-nullable properties.
+   */
+  internal data class MyClass(
+    val value: ZoneId,
+  )
+
+  private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
+
+  @Test
+  fun `serialize, UTC offset`() {
+    mapper.writeValueAsString(MyClass(ZoneOffset.UTC))
+      .shouldBe("{\"value\":\"UTC\"}")
+  }
+
+  @Test
+  fun `serialize, UTC region`() {
+    serializationShouldFail {
+      mapper.writeValueAsString(MyClass(ZoneId.of("UTC")))
+        .shouldBe("{\"value\":\"UTC\"}")
+    }
+  }
+
+  @Test
+  fun `serialize, non-UTC`() {
+    mapper.writeValueAsString(MyClass(ZoneId.of("America/Edmonton")))
+      .shouldBe("{\"value\":\"America/Edmonton\"}")
+  }
+
+  @Test
+  fun `deserialize, UTC offset`() {
+    mapper.readValue<MyClass>("{ \"value\": \"Z\" }")
+      .shouldBe(MyClass(ZoneOffset.UTC))
+  }
+
+  @Test
+  fun `deserialize, UTC region`() {
+    mapper.readValue<MyClass>("{ \"value\": \"UTC\" }")
+      .shouldBe(MyClass(ZoneOffset.UTC))
+  }
+
+  @Test
+  fun `deserialize, non-UTC`() {
+    mapper.readValue<MyClass>("{ \"value\": \"America/Edmonton\" }")
+      .shouldBe(MyClass(ZoneId.of("America/Edmonton")))
+  }
+
+  @Test
+  fun `deserialize, null`() {
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": null }")
+    }
+  }
+
+  @Test
+  fun `deserialize, missing`() {
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{}")
+    }
+  }
+
+  @Test
+  fun `deserialize, nonexistent`() {
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"America/Calgary\" }")
+    }
+  }
+
+  @Test
+  fun `deserialize, wrong type, number`() {
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": 0 }")
+    }
+  }
+}

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/ZoneIdNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/ZoneIdNullableObjectMapperTest.kt
@@ -1,0 +1,66 @@
+package kairo.serialization
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.kotest.matchers.shouldBe
+import java.time.ZoneId
+import java.time.ZoneOffset
+import org.junit.jupiter.api.Test
+
+/**
+ * This test is intended to test behaviour strictly related to zone ID serialization/deserialization.
+ * Therefore, some test cases (such as unknown properties, pretty printing) are not included
+ * since they are not strictly related to zone ID.
+ */
+internal class ZoneIdNullableObjectMapperTest {
+  /**
+   * This test is specifically for nullable properties.
+   */
+  internal data class MyClass(
+    val value: ZoneId?,
+  )
+
+  private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
+
+  @Test
+  fun `serialize, UTC`() {
+    mapper.writeValueAsString(MyClass(ZoneOffset.UTC))
+      .shouldBe("{\"value\":\"UTC\"}")
+  }
+
+  @Test
+  fun `serialize, non-UTC`() {
+    mapper.writeValueAsString(MyClass(ZoneId.of("America/Edmonton")))
+      .shouldBe("{\"value\":\"America/Edmonton\"}")
+  }
+
+  @Test
+  fun `serialize, null`() {
+    mapper.writeValueAsString(MyClass(null))
+      .shouldBe("{\"value\":null}")
+  }
+
+  @Test
+  fun `deserialize, UTC`() {
+    mapper.readValue<MyClass>("{ \"value\": \"UTC\" }")
+      .shouldBe(MyClass(ZoneOffset.UTC))
+  }
+
+  @Test
+  fun `deserialize, non-UTC`() {
+    mapper.readValue<MyClass>("{ \"value\": \"America/Edmonton\" }")
+      .shouldBe(MyClass(ZoneId.of("America/Edmonton")))
+  }
+
+  @Test
+  fun `deserialize, null`() {
+    mapper.readValue<MyClass>("{ \"value\": null }")
+      .shouldBe(MyClass(null))
+  }
+
+  @Test
+  fun `deserialize, missing`() {
+    mapper.readValue<MyClass>("{}")
+      .shouldBe(MyClass(null))
+  }
+}

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/ZoneIdNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/ZoneIdNullableObjectMapperTest.kt
@@ -8,9 +8,9 @@ import java.time.ZoneOffset
 import org.junit.jupiter.api.Test
 
 /**
- * This test is intended to test behaviour strictly related to zone ID serialization/deserialization.
+ * This test is intended to test behaviour strictly related to time zone serialization/deserialization.
  * Therefore, some test cases (such as unknown properties, pretty printing) are not included
- * since they are not strictly related to zone ID.
+ * since they are not strictly related to time zones.
  */
 internal class ZoneIdNullableObjectMapperTest {
   /**

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/ZoneIdNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/ZoneIdNullableObjectMapperTest.kt
@@ -23,9 +23,17 @@ internal class ZoneIdNullableObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, UTC`() {
+  fun `serialize, UTC offset`() {
     mapper.writeValueAsString(MyClass(ZoneOffset.UTC))
       .shouldBe("{\"value\":\"UTC\"}")
+  }
+
+  @Test
+  fun `serialize, UTC region`() {
+    serializationShouldFail {
+      mapper.writeValueAsString(MyClass(ZoneId.of("UTC")))
+        .shouldBe("{\"value\":\"UTC\"}")
+    }
   }
 
   @Test
@@ -41,7 +49,13 @@ internal class ZoneIdNullableObjectMapperTest {
   }
 
   @Test
-  fun `deserialize, UTC`() {
+  fun `deserialize, UTC offset`() {
+    mapper.readValue<MyClass>("{ \"value\": \"Z\" }")
+      .shouldBe(MyClass(ZoneOffset.UTC))
+  }
+
+  @Test
+  fun `deserialize, UTC region`() {
     mapper.readValue<MyClass>("{ \"value\": \"UTC\" }")
       .shouldBe(MyClass(ZoneOffset.UTC))
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/serializationShouldFail.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/serializationShouldFail.kt
@@ -7,5 +7,5 @@ import io.kotest.assertions.throwables.shouldThrow
  * For simplicity, we only check for [JsonMappingException] to ensure deserialization failed.
  * It's possible but unnecessary to check for more specific exception types.
  */
-internal inline fun deserializationShouldFail(block: () -> Any?): JsonMappingException =
+internal inline fun serializationShouldFail(block: () -> Any?): JsonMappingException =
   shouldThrow<JsonMappingException>(block)


### PR DESCRIPTION
### Summary

Time zones need to be serialized so that they can be used in configs and REST interfaces. This PR adds support and tests for time zone serialization. UTC is always deserialized to/from `ZoneOffset.UTC` rather than `ZoneId.of("UTC")`, the latter of which returns the region implementation.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
