### PR TITLE
Add quotes to YAMLs in READMEs

### DIFF
--- a/kairo-clock/README.md
+++ b/kairo-clock/README.md
@@ -22,8 +22,8 @@ dependencies {
 # src/main/resources/config/config.yaml
 
 clock:
-  type: System
-  timeZone: UTC
+  type: "System"
+  timeZone: "UTC"
 ```
 
 ```kotlin

--- a/kairo-id/README.md
+++ b/kairo-id/README.md
@@ -54,7 +54,7 @@ dependencies {
 
 id:
   generator:
-    type: Random
+    type: "Random"
     length: 22
 ```
 


### PR DESCRIPTION
### Summary

Since `kairo-serialization` always serializes using double quotes, let's prefer that in our documentation too.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
