### PR TITLE
Use Kotlin Uuid instead of Java UUID

### DIFF
--- a/.detekt/config.yaml
+++ b/.detekt/config.yaml
@@ -568,6 +568,7 @@ style:
     imports:
       - 'com.google.inject.TypeLiteral' # Use the Kotlin overload.
       - 'jakarta.validation.constraints.*'
+      - 'java.util.UUID' # Use Kotlin.uuid.Uuid instead.
       - 'javax.inject.*'
       - 'kotlin.time.Duration'
       - 'org.junit.jupiter.api.Assertions.*'

--- a/buildSrc/src/main/kotlin/kairo.gradle.kts
+++ b/buildSrc/src/main/kotlin/kairo.gradle.kts
@@ -20,6 +20,7 @@ kotlin {
   explicitApi()
   compilerOptions {
     allWarningsAsErrors.set(true)
+    freeCompilerArgs.add("-opt-in=kotlin.uuid.ExperimentalUuidApi")
   }
 }
 

--- a/kairo-serialization/README.md
+++ b/kairo-serialization/README.md
@@ -19,7 +19,8 @@ because of its limited support for polymorphism.
   - `String`
 - Java
   - `Optional`
-  - `UUID`
+- Kotlin
+  - `Uuid`
 - Date/time
   - `Instant`
   - `LocalDate`

--- a/kairo-serialization/src/main/kotlin/kairo/serialization/ObjectMapperFactoryBuilder.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/ObjectMapperFactoryBuilder.kt
@@ -33,6 +33,8 @@ public class ObjectMapperFactoryBuilder internal constructor(
     configureJava()
     configureStrings()
     configureTime()
+    configureUuid()
+
     increaseStrictness()
     configurePrettyPrinting(prettyPrint = prettyPrint)
     setUnknownPropertyHandling()

--- a/kairo-serialization/src/main/kotlin/kairo/serialization/UuidDeserializer.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/UuidDeserializer.kt
@@ -1,0 +1,18 @@
+package kairo.serialization
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.JsonToken
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import kotlin.uuid.Uuid
+
+/**
+ * Jackson supports [java.util.UUID] by default, but not [kotlin.uuid.Uuid] which we use.
+ */
+internal class UuidDeserializer : StdDeserializer<Uuid>(Uuid::class.java) {
+  override fun deserialize(p: JsonParser, ctxt: DeserializationContext): Uuid {
+    expectCurrentToken(p, ctxt, JsonToken.VALUE_STRING)
+    val string = p.readValueAs<String>()
+    return Uuid.parse(string)
+  }
+}

--- a/kairo-serialization/src/main/kotlin/kairo/serialization/UuidModule.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/UuidModule.kt
@@ -1,0 +1,33 @@
+package kairo.serialization
+
+import com.fasterxml.jackson.databind.deser.Deserializers
+import com.fasterxml.jackson.databind.module.SimpleDeserializers
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.databind.module.SimpleSerializers
+import com.fasterxml.jackson.databind.ser.Serializers
+import kotlin.uuid.Uuid
+
+/**
+ * Jackson supports [java.util.UUID] by default, but not [kotlin.uuid.Uuid] which we use.
+ */
+internal class UuidModule : SimpleModule() {
+  override fun setupModule(context: SetupContext) {
+    super.setupModule(context)
+    context.addSerializers(buildSerializers())
+    context.addDeserializers(buildDeserializers())
+  }
+
+  private fun buildSerializers(): Serializers =
+    SimpleSerializers().apply {
+      addSerializer(Uuid::class.javaObjectType, UuidSerializer())
+    }
+
+  private fun buildDeserializers(): Deserializers =
+    SimpleDeserializers().apply {
+      addDeserializer(Uuid::class.javaObjectType, UuidDeserializer())
+    }
+}
+
+internal fun ObjectMapperFactoryBuilder.configureUuid() {
+  addModule(UuidModule())
+}

--- a/kairo-serialization/src/main/kotlin/kairo/serialization/UuidSerializer.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/UuidSerializer.kt
@@ -1,0 +1,16 @@
+package kairo.serialization
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import kotlin.uuid.Uuid
+
+/**
+ * Jackson supports [java.util.UUID] by default, but not [kotlin.uuid.Uuid] which we use.
+ */
+internal class UuidSerializer : StdSerializer<Uuid>(Uuid::class.java) {
+  override fun serialize(value: Uuid, gen: JsonGenerator, provider: SerializerProvider) {
+    val string = value.toString()
+    gen.writeString(string)
+  }
+}

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/JsonObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/JsonObjectMapperTest.kt
@@ -9,7 +9,7 @@ import io.kotest.matchers.shouldBe
 import java.time.Instant
 import java.time.LocalDate
 import java.util.Optional
-import java.util.UUID
+import kotlin.uuid.Uuid
 import org.junit.jupiter.api.Test
 
 /**
@@ -22,7 +22,7 @@ internal class JsonObjectMapperTest {
     val float: Float,
     val int: Int,
     val strings: Strings,
-    val uuid: UUID,
+    val uuid: Uuid,
     val nested: Nested,
     val optionals: Optionals,
     val instant: Instant,
@@ -82,7 +82,7 @@ internal class JsonObjectMapperTest {
         stringFloat = "1.23",
         stringInt = "42",
       ),
-      uuid = UUID.fromString("3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8"),
+      uuid = Uuid.parse("3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8"),
       nested = MyClass.Nested.NestB(b = "bravo"),
       optionals = MyClass.Optionals(
         optionalPresent = Optional.of(42),

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/UuidDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/UuidDefaultObjectMapperTest.kt
@@ -3,7 +3,7 @@ package kairo.serialization
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
-import java.util.UUID
+import kotlin.uuid.Uuid
 import org.junit.jupiter.api.Test
 
 /**
@@ -16,21 +16,21 @@ internal class UuidDefaultObjectMapperTest {
    * This test is specifically for non-nullable properties.
    */
   internal data class MyClass(
-    val value: UUID,
+    val value: Uuid,
   )
 
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
   fun `serialize, default`() {
-    mapper.writeValueAsString(MyClass(UUID.fromString("3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8")))
+    mapper.writeValueAsString(MyClass(Uuid.parse("3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8")))
       .shouldBe("{\"value\":\"3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8\"}")
   }
 
   @Test
   fun `deserialize, default`() {
     mapper.readValue<MyClass>("{ \"value\": \"3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8\" }")
-      .shouldBe(MyClass(UUID.fromString("3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8")))
+      .shouldBe(MyClass(Uuid.parse("3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8")))
   }
 
   @Test

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/UuidNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/UuidNullableObjectMapperTest.kt
@@ -3,7 +3,7 @@ package kairo.serialization
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
-import java.util.UUID
+import kotlin.uuid.Uuid
 import org.junit.jupiter.api.Test
 
 /**
@@ -16,14 +16,14 @@ internal class UuidNullableObjectMapperTest {
    * This test is specifically for nullable properties.
    */
   internal data class MyClass(
-    val value: UUID?,
+    val value: Uuid?,
   )
 
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
   fun `serialize, default`() {
-    mapper.writeValueAsString(MyClass(UUID.fromString("3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8")))
+    mapper.writeValueAsString(MyClass(Uuid.parse("3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8")))
       .shouldBe("{\"value\":\"3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8\"}")
   }
 
@@ -36,7 +36,7 @@ internal class UuidNullableObjectMapperTest {
   @Test
   fun `deserialize, default`() {
     mapper.readValue<MyClass>("{ \"value\": \"3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8\" }")
-      .shouldBe(MyClass(UUID.fromString("3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8")))
+      .shouldBe(MyClass(Uuid.parse("3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8")))
   }
 
   @Test

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/YamlObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/YamlObjectMapperTest.kt
@@ -9,7 +9,7 @@ import io.kotest.matchers.shouldBe
 import java.time.Instant
 import java.time.LocalDate
 import java.util.Optional
-import java.util.UUID
+import kotlin.uuid.Uuid
 import org.junit.jupiter.api.Test
 
 /**
@@ -22,7 +22,7 @@ internal class YamlObjectMapperTest {
     val float: Float,
     val int: Int,
     val strings: Strings,
-    val uuid: UUID,
+    val uuid: Uuid,
     val nested: Nested,
     val optionals: Optionals,
     val instant: Instant,
@@ -82,7 +82,7 @@ internal class YamlObjectMapperTest {
         stringFloat = "1.23",
         stringInt = "42",
       ),
-      uuid = UUID.fromString("3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8"),
+      uuid = Uuid.parse("3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8"),
       nested = MyClass.Nested.NestB(b = "bravo"),
       optionals = MyClass.Optionals(
         optionalPresent = Optional.of(42),


### PR DESCRIPTION
### Summary

In Kotlin 2.0.20 (which we just upgraded to in #79), Kotlin introduced support for their own `Uuid` class. This PR migrates Kairo from Java `UUID`s to Kotlin `Uuid`s.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
