### PR TITLE
Introduce REST endpoint templates

### DIFF
--- a/.detekt/config.yaml
+++ b/.detekt/config.yaml
@@ -59,7 +59,7 @@ complexity:
     ignoreOverloaded: false
   CyclomaticComplexMethod: # Unsure how this differs from CognitiveComplexMethod and if one is preferable.
     active: true
-    threshold: 10
+    threshold: 12
     ignoreSingleWhenExpression: true
     ignoreSimpleWhenEntries: true
     ignoreNestingFunctions: false

--- a/.detekt/config.yaml
+++ b/.detekt/config.yaml
@@ -47,7 +47,7 @@ comments:
 complexity:
   CognitiveComplexMethod:
     active: true # Unsure how this differs from CyclomaticComplexMethod and if one is preferable.
-    threshold: 10
+    threshold: 12
   ComplexCondition:
     active: true
     threshold: 2
@@ -69,7 +69,7 @@ complexity:
     active: false # Good practice, but leave this up to the developer.
   LongMethod:
     active: true
-    threshold: 20
+    threshold: 30
   LongParameterList:
     active: true
     functionThreshold: 4
@@ -509,7 +509,7 @@ potential-bugs:
   UnreachableCode:
     active: true
   UnsafeCallOnNullableType:
-    active: true
+    active: false # checkNotNull and requireNotNull are often preferable, but leaving this open.
   UnsafeCast:
     active: true
   UnusedUnaryOperator:

--- a/kairo-id-feature/src/main/kotlin/kairo/id/DeterministicKairoIdGenerator.kt
+++ b/kairo-id-feature/src/main/kotlin/kairo/id/DeterministicKairoIdGenerator.kt
@@ -10,15 +10,12 @@ import java.util.concurrent.ConcurrentHashMap
  */
 public class DeterministicKairoIdGenerator(
   prefix: String,
-  length: Int,
 ) : KairoIdGenerator(prefix, length) {
-  public class Factory(
-    private val length: Int,
-  ) : KairoIdGenerator.Factory() {
+  public object Factory : KairoIdGenerator.Factory() {
     private val generators: MutableMap<String, DeterministicKairoIdGenerator> = ConcurrentHashMap()
 
     override fun withPrefix(prefix: String): DeterministicKairoIdGenerator =
-      generators.getOrPut(prefix) { DeterministicKairoIdGenerator(prefix, length) }
+      generators.getOrPut(prefix) { DeterministicKairoIdGenerator(prefix) }
 
     public fun reset() {
       generators.values.forEach { it.reset() }
@@ -31,9 +28,19 @@ public class DeterministicKairoIdGenerator(
     seed = 0
   }
 
-  override fun generate(): KairoId =
-    get(seed).also { seed++ }
+  override fun generate(): KairoId {
+    val result = get(seed)
+    seed++
+    return result
+  }
 
-  public operator fun get(i: Int): KairoId =
-    KairoId(prefix, i.toString().padStart(length, '0'))
+  public operator fun get(id: Int): KairoId =
+    generate(prefix, id)
+
+  public companion object {
+    private const val length: Int = 8
+
+    public fun generate(prefix: String, id: Int): KairoId =
+      KairoId(prefix, id.toString().padStart(length, '0'))
+  }
 }

--- a/kairo-id-feature/src/main/kotlin/kairo/id/KairoIdConfig.kt
+++ b/kairo-id-feature/src/main/kotlin/kairo/id/KairoIdConfig.kt
@@ -12,14 +12,10 @@ public data class KairoIdConfig(
     JsonSubTypes.Type(Generator.Random::class, name = "Random"),
   )
   public sealed class Generator {
-    public data class Deterministic(
-      override val length: Int,
-    ) : Generator()
+    public data object Deterministic : Generator()
 
     public data class Random(
-      override val length: Int,
+      val length: Int,
     ) : Generator()
-
-    public abstract val length: Int
   }
 }

--- a/kairo-id-feature/src/main/kotlin/kairo/id/KairoIdFeature.kt
+++ b/kairo-id-feature/src/main/kotlin/kairo/id/KairoIdFeature.kt
@@ -18,7 +18,7 @@ public class KairoIdFeature(
 
   private fun createGenerator(config: KairoIdConfig.Generator): KairoIdGenerator.Factory =
     when (config) {
-      is KairoIdConfig.Generator.Deterministic -> DeterministicKairoIdGenerator.Factory(length = config.length)
+      is KairoIdConfig.Generator.Deterministic -> DeterministicKairoIdGenerator.Factory
       is KairoIdConfig.Generator.Random -> RandomKairoIdGenerator.Factory(length = config.length)
     }
 }

--- a/kairo-id-feature/src/test/kotlin/kairo/id/DeterministicKairoIdGeneratorTest.kt
+++ b/kairo-id-feature/src/test/kotlin/kairo/id/DeterministicKairoIdGeneratorTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 
 internal class DeterministicKairoIdGeneratorTest {
   private val idGenerator: DeterministicKairoIdGenerator =
-    DeterministicKairoIdGenerator(prefix = "library_book", length = 8)
+    DeterministicKairoIdGenerator(prefix = "library_book")
 
   @Test
   fun test() {

--- a/kairo-rest-feature/README.md
+++ b/kairo-rest-feature/README.md
@@ -21,6 +21,8 @@ dependencies {
 REST endpoint implementations define the API contract for REST API endpoints.
 They are intended to be grouped together using Kotlin singleton objects.
 
+Implementations must be Kotlin data classes or data objects.
+
 It's perfectly acceptable for two endpoints to have the same method and path,
 as long as they differ by query params, accept headers, or content types.
 Routing takes all of these into account.
@@ -30,19 +32,19 @@ Routing takes all of these into account.
 
 object LibraryBookApi {
   @RestEndpoint.Method("GET")
-  @RestEndpoint.Path("/library/books/:bookId")
+  @RestEndpoint.Path("/library/library-books/:libraryBookId")
   @RestEndpoint.Accept("application/json")
   data class Get(
-    @PathParam val bookId: KairoId,
+    @PathParam val libraryBookId: KairoId,
   ) : RestEndpoint<Nothing, BookRep?>()
 
   @RestEndpoint.Method("GET")
-  @RestEndpoint.Path("/library/books")
+  @RestEndpoint.Path("/library/library-books")
   @RestEndpoint.Accept("application/json")
   data object ListAll : RestEndpoint<Nothing, List<BookRep>>()
 
   @RestEndpoint.Method("POST")
-  @RestEndpoint.Path("/library/books")
+  @RestEndpoint.Path("/library/library-books")
   @RestEndpoint.ContentType("application/json")
   @RestEndpoint.Accept("application/json")
   data class Create(

--- a/kairo-rest-feature/build.gradle.kts
+++ b/kairo-rest-feature/build.gradle.kts
@@ -9,4 +9,9 @@ dependencies {
 
   implementation(libs.ktorServerCio)
   implementation(libs.ktorServerCore)
+
+  testImplementation(project(":kairo-id-feature"))
+  testImplementation(project(":kairo-logging:testing"))
+  testImplementation(project(":kairo-serialization"))
+  testImplementation(project(":testing"))
 }

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpoint.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpoint.kt
@@ -1,7 +1,11 @@
 package kairo.restFeature
 
+import kotlin.reflect.KClass
+import kotlin.reflect.full.memberProperties
+
 /**
  * A [RestEndpoint] implementation defines the API contract for a single REST API endpoint.
+ * Implementations must be Kotlin data classes or data objects.
  * See this Feature's README or tests for some examples.
  *
  * [Request] represents the type of the request body. If none, use [Nothing].
@@ -15,7 +19,7 @@ public abstract class RestEndpoint<Request : Any, Response : Any?> {
   public annotation class Method(val method: String)
 
   /**
-   * Mandatory: the path should be something like "/library/book/:bookId".
+   * Mandatory: the path should be something like "/library/library-books/:libraryBookId".
    */
   @Target(AnnotationTarget.CLASS)
   public annotation class Path(val path: String)
@@ -51,3 +55,9 @@ public abstract class RestEndpoint<Request : Any, Response : Any?> {
    */
   public open val body: Request? = null
 }
+
+internal val KClass<out RestEndpoint<*, *>>.hasBody: Boolean
+  get() {
+    val body = memberProperties.single { it.name == RestEndpoint<*, *>::body.name }
+    return body.returnType.classifier != Nothing::class
+  }

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointPath.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointPath.kt
@@ -1,5 +1,9 @@
 package kairo.restFeature
 
+/**
+ * Part of [RestEndpointTemplate] that represents the path, including path params.
+ * See the KDoc there.
+ */
 internal data class RestEndpointPath(
   val components: List<Component>,
 ) {

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointPath.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointPath.kt
@@ -1,0 +1,37 @@
+package kairo.restFeature
+
+internal data class RestEndpointPath(
+  val components: List<Component>,
+) {
+  internal sealed class Component {
+    internal data class Constant(val value: String) : Component() {
+      private val regex: Regex = Regex("[a-z][a-z0-9]*(-[a-z][a-z0-9]*)*")
+
+      init {
+        require(regex.matches(value)) { "Path constants must be kebab case: $value." }
+      }
+    }
+
+    internal data class Param(val value: String) : Component() {
+      private val regex: Regex = Regex("[a-z][A-Za-z0-9]*")
+
+      init {
+        require(regex.matches(value)) { "Path params must be camel case: $value." }
+      }
+    }
+
+    internal companion object {
+      fun from(value: String): Component =
+        if (value.startsWith(':')) {
+          Param(value.substring(1))
+        } else {
+          Constant(value)
+        }
+    }
+  }
+
+  internal companion object {
+    fun of(vararg components: Component): RestEndpointPath =
+      RestEndpointPath(components.toList())
+  }
+}

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointQuery.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointQuery.kt
@@ -1,0 +1,23 @@
+package kairo.restFeature
+
+import kairo.restFeature.RestEndpointPath.Component
+
+internal data class RestEndpointQuery(
+  val params: List<Param>,
+) {
+  internal data class Param(
+    val value: String,
+    val required: Boolean,
+  ) : Component() {
+    private val regex: Regex = Regex("[a-z][A-Za-z0-9]*")
+
+    init {
+      require(regex.matches(value)) { "Query params must be camel case: $value." }
+    }
+  }
+
+  internal companion object {
+    fun of(vararg params: Param): RestEndpointQuery =
+      RestEndpointQuery(params.toList())
+  }
+}

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointQuery.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointQuery.kt
@@ -2,6 +2,10 @@ package kairo.restFeature
 
 import kairo.restFeature.RestEndpointPath.Component
 
+/**
+ * Part of [RestEndpointTemplate] that represents query params.
+ * See the KDoc there.
+ */
 internal data class RestEndpointQuery(
   val params: List<Param>,
 ) {

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointTemplate.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointTemplate.kt
@@ -1,0 +1,176 @@
+package kairo.restFeature
+
+import io.ktor.http.BadContentTypeFormatException
+import io.ktor.http.ContentType
+import io.ktor.http.HttpMethod
+import kotlin.reflect.KClass
+import kotlin.reflect.KParameter
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.hasAnnotation
+import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.full.valueParameters
+
+/**
+ * A REST endpoint template instance represents a specific subclass of [RestEndpoint].
+ * In fact, it can be created from a [RestEndpoint] class reference using [RestEndpointTemplate.parse].
+ */
+internal data class RestEndpointTemplate(
+  val method: HttpMethod,
+  val path: RestEndpointPath,
+  val query: RestEndpointQuery,
+  val contentType: ContentType?,
+  val accept: ContentType,
+) {
+  internal companion object {
+    fun parse(endpoint: KClass<out RestEndpoint<*, *>>): RestEndpointTemplate {
+      require(endpoint.isData) { "REST endpoint ${endpoint.qualifiedName!!} must be a data class or data object." }
+      validateParams(endpoint)
+      return RestEndpointTemplate(
+        method = parseMethod(endpoint),
+        path = parsePath(endpoint),
+        query = parseQuery(endpoint),
+        contentType = parseContentType(endpoint),
+        accept = parseAccept(endpoint),
+      )
+    }
+
+    private fun validateParams(endpoint: KClass<out RestEndpoint<*, *>>) {
+      val params = getAllParams(endpoint)
+      params.forEach { param ->
+        val isPath = param.hasAnnotation<RestEndpoint.PathParam>()
+        val isQuery = param.hasAnnotation<RestEndpoint.QueryParam>()
+        if (param.name == RestEndpoint<*, *>::body.name) {
+          require(!isPath && !isQuery) { "REST endpoint ${endpoint.qualifiedName!!} body cannot be param." }
+          return
+        }
+        require(!(isPath && isQuery)) {
+          "REST endpoint ${endpoint.qualifiedName!!} param cannot be both path and query: ${param.name!!}."
+        }
+        require(isPath || isQuery) {
+          "REST endpoint ${endpoint.qualifiedName!!} param must be path or query: ${param.name!!}."
+        }
+      }
+    }
+
+    private fun parseMethod(endpoint: KClass<out RestEndpoint<*, *>>): HttpMethod {
+      val annotation = endpoint.findAnnotation<RestEndpoint.Method>()
+      requireNotNull(annotation) {
+        "REST endpoint ${endpoint.qualifiedName!!} is missing @${RestEndpoint.Method::class.simpleName!!}."
+      }
+      val result = HttpMethod.parse(annotation.method) // This does not fail, even for arbitrary strings.
+      require(result in HttpMethod.DefaultMethods) {
+        "REST endpoint ${endpoint.qualifiedName!!} has invalid method: ${annotation.method}."
+      }
+      return result
+    }
+
+    private fun parsePath(endpoint: KClass<out RestEndpoint<*, *>>): RestEndpointPath {
+      val annotation = endpoint.findAnnotation<RestEndpoint.Path>()
+      requireNotNull(annotation) {
+        "REST endpoint ${endpoint.qualifiedName!!} is missing @${RestEndpoint.Path::class.simpleName!!}."
+      }
+      require(annotation.path.startsWith("/")) {
+        "REST endpoint ${endpoint.qualifiedName!!} path must start with a slash: ${annotation.path}."
+      }
+      try {
+        val result = RestEndpointPath(
+          components = annotation.path.drop(1).split('/').map { RestEndpointPath.Component.from(it) },
+        )
+        result.validate(endpoint)
+        return result
+      } catch (e: IllegalArgumentException) {
+        val error = listOfNotNull(
+          "REST endpoint ${endpoint.qualifiedName!!} path is invalid.",
+          e.message,
+        ).joinToString(" ")
+        throw IllegalArgumentException(error, e)
+      }
+    }
+
+    private fun RestEndpointPath.validate(endpoint: KClass<out RestEndpoint<*, *>>) {
+      val componentNames = components.filterIsInstance<RestEndpointPath.Component.Param>().map { it.value }
+      val params = getParams<RestEndpoint.PathParam>(endpoint)
+      params.forEach { param ->
+        require(!param.type.isMarkedNullable) { "Path param must not be nullable: ${param.name!!}." }
+        require(!param.isOptional) { "Path param must not be optional: ${param.name!!}." }
+      }
+      val paramNames = params.map { it.name!! }
+      componentNames.forEachIndexed { i, componentName ->
+        require(componentName !in componentNames.subList(0, i)) { "Duplicate path param in path: $componentName." }
+        require(componentName in paramNames) { "Path param in path but not in constructor: $componentName." }
+      }
+      paramNames.forEach { paramName ->
+        require(paramName in componentNames) { "Path param in constructor but not in path: $paramName." }
+      }
+    }
+
+    private fun parseQuery(endpoint: KClass<out RestEndpoint<*, *>>): RestEndpointQuery {
+      val params = getParams<RestEndpoint.QueryParam>(endpoint)
+      params.forEach { param ->
+        "REST endpoint ${endpoint.qualifiedName!!} query is invalid. Query param must not be optional: ${param.name!!}."
+      }
+      return RestEndpointQuery(
+        params = params.map { param ->
+          RestEndpointQuery.Param(value = param.name!!, required = !param.type.isMarkedNullable)
+        },
+      )
+    }
+
+    private fun parseContentType(endpoint: KClass<out RestEndpoint<*, *>>): ContentType? {
+      val annotation = endpoint.findAnnotation<RestEndpoint.ContentType>()
+      val hasBody = endpoint.hasBody
+      if (hasBody) {
+        requireNotNull(annotation) {
+          "REST endpoint ${endpoint.qualifiedName!!} requires @${RestEndpoint.ContentType::class.simpleName!!}" +
+            " since it has a body."
+        }
+        try {
+          return ContentType.parse(annotation.contentType)
+        } catch (e: BadContentTypeFormatException) {
+          val error = listOfNotNull(
+            "REST endpoint ${endpoint.qualifiedName!!} content type is invalid.",
+            "${e.message}.",
+          ).joinToString(" ")
+          throw IllegalArgumentException(error, e)
+        }
+      } else {
+        require(annotation == null) {
+          "REST endpoint ${endpoint.qualifiedName!!} may not have @${RestEndpoint.ContentType::class.simpleName!!}" +
+            " since it does not have a body."
+        }
+        return null
+      }
+    }
+
+    private fun parseAccept(endpoint: KClass<out RestEndpoint<*, *>>): ContentType {
+      val annotation = endpoint.findAnnotation<RestEndpoint.Accept>()
+      requireNotNull(annotation) {
+        "REST endpoint ${endpoint.qualifiedName!!} requires @${RestEndpoint.Accept::class.simpleName!!}."
+      }
+      try {
+        return ContentType.parse(annotation.accept)
+      } catch (e: BadContentTypeFormatException) {
+        val error = listOfNotNull(
+          "REST endpoint ${endpoint.qualifiedName!!} accept is invalid.",
+          "${e.message}.",
+        ).joinToString(" ")
+        throw IllegalArgumentException(error, e)
+      }
+    }
+
+    private inline fun <reified T : Annotation> getParams(
+      endpoint: KClass<out RestEndpoint<*, *>>,
+    ): List<KParameter> {
+      val params = getAllParams(endpoint)
+      return params.filter { parameter -> parameter.hasAnnotation<T>() }
+    }
+
+    private fun getAllParams(
+      endpoint: KClass<out RestEndpoint<*, *>>,
+    ): List<KParameter> {
+      if (endpoint.objectInstance != null) return emptyList()
+      val constructor = checkNotNull(endpoint.primaryConstructor) { "Data classes always have primary constructors." }
+      return constructor.valueParameters
+    }
+  }
+}

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointTemplate.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointTemplate.kt
@@ -63,9 +63,6 @@ internal data class RestEndpointTemplate(
         "REST endpoint ${endpoint.qualifiedName!!} is missing @${RestEndpoint.Method::class.simpleName!!}."
       }
       val result = HttpMethod.parse(annotation.method) // This does not fail, even for arbitrary strings.
-      require(result in HttpMethod.DefaultMethods) {
-        "REST endpoint ${endpoint.qualifiedName!!} has invalid method: ${annotation.method}."
-      }
       result.validate(endpoint)
       return result
     }
@@ -77,18 +74,18 @@ internal data class RestEndpointTemplate(
       when (this) {
         HttpMethod.Get, HttpMethod.Delete, HttpMethod.Head, HttpMethod.Options -> {
           require(!endpoint.hasBody) {
-            "REST endpoint ${endpoint.qualifiedName!!} has method $this but specifies a body."
+            "REST endpoint ${endpoint.qualifiedName!!} has method $value but specifies a body."
           }
         }
 
         HttpMethod.Post, HttpMethod.Put, HttpMethod.Patch -> {
           require(endpoint.hasBody) {
-            "REST endpoint ${endpoint.qualifiedName!!} has method $this but specifies a body."
+            "REST endpoint ${endpoint.qualifiedName!!} has method $value but specifies a body."
           }
         }
 
         else -> {
-          error("Unexpected HTTP method $this.")
+          throw IllegalArgumentException("REST endpoint ${endpoint.qualifiedName!!} has invalid method: ${value}.")
         }
       }
     }

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointTemplate.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointTemplate.kt
@@ -34,6 +34,11 @@ internal data class RestEndpointTemplate(
       )
     }
 
+    /**
+     * This method only ensures that params have the right annotations.
+     * Param specifics and how their annotations relate to class-level annotations such as [RestEndpoint.Path]
+     * are validated within the appropriate parse methods in this class.
+     */
     private fun validateParams(endpoint: KClass<out RestEndpoint<*, *>>) {
       val params = getAllParams(endpoint)
       params.forEach { param ->
@@ -87,6 +92,10 @@ internal data class RestEndpointTemplate(
       }
     }
 
+    /**
+     * Ensures that the path params specified in the constructor
+     * are consistent with the param path components from the [RestEndpoint.Path] annotation.
+     */
     private fun RestEndpointPath.validate(endpoint: KClass<out RestEndpoint<*, *>>) {
       val componentNames = components.filterIsInstance<RestEndpointPath.Component.Param>().map { it.value }
       val params = getParams<RestEndpoint.PathParam>(endpoint)

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointTemplate.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointTemplate.kt
@@ -85,7 +85,7 @@ internal data class RestEndpointTemplate(
         }
 
         else -> {
-          throw IllegalArgumentException("REST endpoint ${endpoint.qualifiedName!!} has invalid method: ${value}.")
+          throw IllegalArgumentException("REST endpoint ${endpoint.qualifiedName!!} has invalid method: $value.")
         }
       }
     }

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointTemplate.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointTemplate.kt
@@ -1,5 +1,7 @@
 package kairo.restFeature
 
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.http.BadContentTypeFormatException
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
@@ -9,6 +11,8 @@ import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.hasAnnotation
 import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.full.valueParameters
+
+private val logger: KLogger = KotlinLogging.logger {}
 
 /**
  * A REST endpoint template instance represents a specific subclass of [RestEndpoint].
@@ -23,15 +27,18 @@ internal data class RestEndpointTemplate(
 ) {
   internal companion object {
     fun parse(endpoint: KClass<out RestEndpoint<*, *>>): RestEndpointTemplate {
+      logger.debug { "Building REST endpoint template for endpoint $endpoint." }
       require(endpoint.isData) { "REST endpoint ${endpoint.qualifiedName!!} must be a data class or data object." }
       validateParams(endpoint)
-      return RestEndpointTemplate(
+      val result = RestEndpointTemplate(
         method = parseMethod(endpoint),
         path = parsePath(endpoint),
         query = parseQuery(endpoint),
         contentType = parseContentType(endpoint),
         accept = parseAccept(endpoint),
       )
+      logger.debug { "Built REST endpoint template $result for endpoint $endpoint." }
+      return result
     }
 
     /**

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenAcceptLibraryBookApi.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenAcceptLibraryBookApi.kt
@@ -24,19 +24,17 @@ internal object BrokenAcceptLibraryBookApi {
   /**
    * This is actually valid; an empty string means "Any" content type.
    */
-  @RestEndpoint.Method("POST")
-  @RestEndpoint.Path("/library/library-books")
-  @RestEndpoint.ContentType("application/json")
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("/library/library-books/:libraryBookId")
   @RestEndpoint.Accept("")
   internal data class EmptyAccept(
-    override val body: LibraryBookRep.Creator,
-  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+    @PathParam val libraryBookId: KairoId,
+  ) : RestEndpoint<Nothing, LibraryBookRep>()
 
-  @RestEndpoint.Method("POST")
-  @RestEndpoint.Path("/library/library-books")
-  @RestEndpoint.ContentType("application/json")
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("/library/library-books/:libraryBookId")
   @RestEndpoint.Accept("application")
   internal data class MalformedAccept(
-    override val body: LibraryBookRep.Creator,
-  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+    @PathParam val libraryBookId: KairoId,
+  ) : RestEndpoint<Nothing, LibraryBookRep>()
 }

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenAcceptLibraryBookApi.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenAcceptLibraryBookApi.kt
@@ -29,12 +29,12 @@ internal object BrokenAcceptLibraryBookApi {
   @RestEndpoint.Accept("")
   internal data class EmptyAccept(
     @PathParam val libraryBookId: KairoId,
-  ) : RestEndpoint<Nothing, LibraryBookRep>()
+  ) : RestEndpoint<Nothing, LibraryBookRep?>()
 
   @RestEndpoint.Method("GET")
   @RestEndpoint.Path("/library/library-books/:libraryBookId")
   @RestEndpoint.Accept("application")
   internal data class MalformedAccept(
     @PathParam val libraryBookId: KairoId,
-  ) : RestEndpoint<Nothing, LibraryBookRep>()
+  ) : RestEndpoint<Nothing, LibraryBookRep?>()
 }

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenAcceptLibraryBookApi.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenAcceptLibraryBookApi.kt
@@ -1,0 +1,42 @@
+package kairo.restFeature
+
+import kairo.id.KairoId
+
+/**
+ * This API is for [BrokenAcceptRestEndpointTemplateTest]
+ * which tests cases where the [RestEndpoint.Accept] annotation
+ * is used in unexpected or unsupported ways.
+ */
+internal object BrokenAcceptLibraryBookApi {
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("/library/library-books/:libraryBookId")
+  internal data class AcceptNotPresentOnGet(
+    @PathParam val libraryBookId: KairoId,
+  ) : RestEndpoint<Nothing, LibraryBookRep?>()
+
+  @RestEndpoint.Method("POST")
+  @RestEndpoint.Path("/library/library-books")
+  @RestEndpoint.ContentType("application/json")
+  internal data class AcceptNotPresentOnPost(
+    override val body: LibraryBookRep.Creator,
+  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+
+  /**
+   * This is actually valid; an empty string means "Any" content type.
+   */
+  @RestEndpoint.Method("POST")
+  @RestEndpoint.Path("/library/library-books")
+  @RestEndpoint.ContentType("application/json")
+  @RestEndpoint.Accept("")
+  internal data class EmptyAccept(
+    override val body: LibraryBookRep.Creator,
+  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+
+  @RestEndpoint.Method("POST")
+  @RestEndpoint.Path("/library/library-books")
+  @RestEndpoint.ContentType("application/json")
+  @RestEndpoint.Accept("application")
+  internal data class MalformedAccept(
+    override val body: LibraryBookRep.Creator,
+  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+}

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenAcceptRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenAcceptRestEndpointTemplateTest.kt
@@ -41,13 +41,14 @@ internal class BrokenAcceptRestEndpointTemplateTest {
     RestEndpointTemplate.parse(BrokenAcceptLibraryBookApi.EmptyAccept::class)
       .shouldBe(
         RestEndpointTemplate(
-          method = HttpMethod.Post,
+          method = HttpMethod.Get,
           path = RestEndpointPath.of(
             RestEndpointPath.Component.Constant("library"),
             RestEndpointPath.Component.Constant("library-books"),
+            RestEndpointPath.Component.Param("libraryBookId"),
           ),
           query = RestEndpointQuery.of(),
-          contentType = ContentType.Application.Json,
+          contentType = null,
           accept = ContentType.Any,
         ),
       )

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenAcceptRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenAcceptRestEndpointTemplateTest.kt
@@ -1,0 +1,65 @@
+package kairo.restFeature
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.throwable.shouldHaveMessage
+import io.ktor.http.ContentType
+import io.ktor.http.HttpMethod
+import org.junit.jupiter.api.Test
+
+/**
+ * This test uses [BrokenAcceptLibraryBookApi]
+ * to test cases where the [RestEndpoint.Accept] annotation
+ * is used in unexpected or unsupported ways.
+ */
+internal class BrokenAcceptRestEndpointTemplateTest {
+  @Test
+  fun acceptPresentOnGet() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenAcceptLibraryBookApi.AcceptNotPresentOnGet::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenAcceptLibraryBookApi.AcceptNotPresentOnGet" +
+        " requires @Accept.",
+    )
+  }
+
+  @Test
+  fun acceptNotPresentOnPost() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenAcceptLibraryBookApi.AcceptNotPresentOnPost::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenAcceptLibraryBookApi.AcceptNotPresentOnPost" +
+        " requires @Accept.",
+    )
+  }
+
+  /**
+   * This is actually valid; an empty string means "Any" content type.
+   */
+  @Test
+  fun emptyAccept() {
+    RestEndpointTemplate.parse(BrokenAcceptLibraryBookApi.EmptyAccept::class)
+      .shouldBe(
+        RestEndpointTemplate(
+          method = HttpMethod.Post,
+          path = RestEndpointPath.of(
+            RestEndpointPath.Component.Constant("library"),
+            RestEndpointPath.Component.Constant("library-books"),
+          ),
+          query = RestEndpointQuery.of(),
+          contentType = ContentType.Application.Json,
+          accept = ContentType.Any,
+        ),
+      )
+  }
+
+  @Test
+  fun malformedAccept() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenAcceptLibraryBookApi.MalformedAccept::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenAcceptLibraryBookApi.MalformedAccept" +
+        " accept is invalid. Bad Content-Type format: application.",
+    )
+  }
+}

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenContentTypeLibraryBookApi.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenContentTypeLibraryBookApi.kt
@@ -1,0 +1,44 @@
+package kairo.restFeature
+
+import kairo.id.KairoId
+
+/**
+ * This API is for [BrokenContentTypeRestEndpointTemplateTest]
+ * which tests cases where the [RestEndpoint.ContentType] annotation
+ * is used in unexpected or unsupported ways.
+ */
+internal object BrokenContentTypeLibraryBookApi {
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("/library/library-books/:libraryBookId")
+  @RestEndpoint.ContentType("application/json")
+  @RestEndpoint.Accept("application/json")
+  internal data class ContentTypePresentOnGet(
+    @PathParam val libraryBookId: KairoId,
+  ) : RestEndpoint<Nothing, LibraryBookRep?>()
+
+  @RestEndpoint.Method("POST")
+  @RestEndpoint.Path("/library/library-books")
+  @RestEndpoint.Accept("application/json")
+  internal data class ContentTypeNotPresentOnPost(
+    override val body: LibraryBookRep.Creator,
+  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+
+  /**
+   * This is actually valid; an empty string means "Any" content type.
+   */
+  @RestEndpoint.Method("POST")
+  @RestEndpoint.Path("/library/library-books")
+  @RestEndpoint.ContentType("")
+  @RestEndpoint.Accept("application/json")
+  internal data class EmptyContentType(
+    override val body: LibraryBookRep.Creator,
+  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+
+  @RestEndpoint.Method("POST")
+  @RestEndpoint.Path("/library/library-books")
+  @RestEndpoint.ContentType("application")
+  @RestEndpoint.Accept("application/json")
+  internal data class MalformedContentType(
+    override val body: LibraryBookRep.Creator,
+  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+}

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenContentTypeRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenContentTypeRestEndpointTemplateTest.kt
@@ -1,0 +1,65 @@
+package kairo.restFeature
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.throwable.shouldHaveMessage
+import io.ktor.http.ContentType
+import io.ktor.http.HttpMethod
+import org.junit.jupiter.api.Test
+
+/**
+ * This test uses [BrokenContentTypeLibraryBookApi]
+ * to test cases where the [RestEndpoint.ContentType] annotation
+ * is used in unexpected or unsupported ways.
+ */
+internal class BrokenContentTypeRestEndpointTemplateTest {
+  @Test
+  fun contentTypePresentOnGet() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenContentTypeLibraryBookApi.ContentTypePresentOnGet::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenContentTypeLibraryBookApi.ContentTypePresentOnGet" +
+        " may not have @ContentType since it does not have a body.",
+    )
+  }
+
+  @Test
+  fun contentTypeNotPresentOnPost() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenContentTypeLibraryBookApi.ContentTypeNotPresentOnPost::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenContentTypeLibraryBookApi.ContentTypeNotPresentOnPost" +
+        " requires @ContentType since it has a body.",
+    )
+  }
+
+  /**
+   * This is actually valid; an empty string means "Any" content type.
+   */
+  @Test
+  fun emptyContentType() {
+    RestEndpointTemplate.parse(BrokenContentTypeLibraryBookApi.EmptyContentType::class)
+      .shouldBe(
+        RestEndpointTemplate(
+          method = HttpMethod.Post,
+          path = RestEndpointPath.of(
+            RestEndpointPath.Component.Constant("library"),
+            RestEndpointPath.Component.Constant("library-books"),
+          ),
+          query = RestEndpointQuery.of(),
+          contentType = ContentType.Any,
+          accept = ContentType.Application.Json,
+        ),
+      )
+  }
+
+  @Test
+  fun malformedContentType() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenContentTypeLibraryBookApi.MalformedContentType::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenContentTypeLibraryBookApi.MalformedContentType" +
+        " content type is invalid. Bad Content-Type format: application.",
+    )
+  }
+}

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenLibraryBookApi.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenLibraryBookApi.kt
@@ -17,5 +17,5 @@ internal object BrokenLibraryBookApi {
   @RestEndpoint.Method("GET")
   @RestEndpoint.Path("/library/library-books")
   @RestEndpoint.Accept("application/json")
-  internal object NotDataObject : RestEndpoint<Nothing, LibraryBookRep?>()
+  internal object NotDataObject : RestEndpoint<Nothing, List<LibraryBookRep>>()
 }

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenLibraryBookApi.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenLibraryBookApi.kt
@@ -1,0 +1,21 @@
+package kairo.restFeature
+
+import kairo.id.KairoId
+
+/**
+ * This API is for [BrokenRestEndpointTemplateTest]
+ * which tests simple invalid cases not related to a particular [RestEndpoint] annotation.
+ */
+internal object BrokenLibraryBookApi {
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("/library/library-books/:libraryBookId")
+  @RestEndpoint.Accept("application/json")
+  internal class NotDataClass(
+    @PathParam val libraryBookId: KairoId,
+  ) : RestEndpoint<Nothing, LibraryBookRep?>()
+
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("/library/library-books")
+  @RestEndpoint.Accept("application/json")
+  internal object NotDataObject : RestEndpoint<Nothing, LibraryBookRep?>()
+}

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenMethodLibraryBookApi.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenMethodLibraryBookApi.kt
@@ -1,0 +1,25 @@
+package kairo.restFeature
+
+/**
+ * This API is for [BrokenMethodRestEndpointTemplateTest]
+ * which tests cases where the [RestEndpoint.Method] annotation
+ * is used in unexpected or unsupported ways.
+ */
+internal object BrokenMethodLibraryBookApi {
+  @RestEndpoint.Path("/library/library-books")
+  @RestEndpoint.Accept("application/json")
+  internal data object MissingMethod : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+
+  @RestEndpoint.Method("")
+  @RestEndpoint.Path("/library/library-books")
+  @RestEndpoint.Accept("application/json")
+  internal data object EmptyMethod : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+
+  @RestEndpoint.Method("SYNC")
+  @RestEndpoint.Path("/library/library-books")
+  @RestEndpoint.ContentType("application/json")
+  @RestEndpoint.Accept("application/json")
+  internal data class Sync(
+    override val body: LibraryBookRep.Creator,
+  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+}

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenMethodLibraryBookApi.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenMethodLibraryBookApi.kt
@@ -1,25 +1,30 @@
 package kairo.restFeature
 
+import kairo.id.KairoId
+
 /**
  * This API is for [BrokenMethodRestEndpointTemplateTest]
  * which tests cases where the [RestEndpoint.Method] annotation
  * is used in unexpected or unsupported ways.
  */
 internal object BrokenMethodLibraryBookApi {
-  @RestEndpoint.Path("/library/library-books")
+  @RestEndpoint.Path("/library/library-books/:libraryBookId")
   @RestEndpoint.Accept("application/json")
-  internal data object MissingMethod : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+  internal data class MissingMethod(
+    @PathParam val libraryBookId: KairoId,
+  ) : RestEndpoint<Nothing, LibraryBookRep?>()
 
   @RestEndpoint.Method("")
-  @RestEndpoint.Path("/library/library-books")
+  @RestEndpoint.Path("/library/library-books/:libraryBookId")
   @RestEndpoint.Accept("application/json")
-  internal data object EmptyMethod : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+  internal data class EmptyMethod(
+    @PathParam val libraryBookId: KairoId,
+  ) : RestEndpoint<Nothing, LibraryBookRep?>()
 
   @RestEndpoint.Method("SYNC")
-  @RestEndpoint.Path("/library/library-books")
-  @RestEndpoint.ContentType("application/json")
+  @RestEndpoint.Path("/library/library-books/:libraryBookId")
   @RestEndpoint.Accept("application/json")
-  internal data class Sync(
-    override val body: LibraryBookRep.Creator,
-  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+  internal data class UnsupportedMethod(
+    @PathParam val libraryBookId: KairoId,
+  ) : RestEndpoint<Nothing, LibraryBookRep?>()
 }

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenMethodRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenMethodRestEndpointTemplateTest.kt
@@ -1,0 +1,42 @@
+package kairo.restFeature
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.throwable.shouldHaveMessage
+import org.junit.jupiter.api.Test
+
+/**
+ * This test uses [BrokenMethodLibraryBookApi]
+ * to test cases where the [RestEndpoint.Method] annotation
+ * is used in unexpected or unsupported ways.
+ */
+internal class BrokenMethodRestEndpointTemplateTest {
+  @Test
+  fun missingMethod() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenMethodLibraryBookApi.MissingMethod::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenMethodLibraryBookApi.MissingMethod" +
+        " is missing @Method.",
+    )
+  }
+
+  @Test
+  fun emptyMethod() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenMethodLibraryBookApi.EmptyMethod::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenMethodLibraryBookApi.EmptyMethod" +
+        " has invalid method: .",
+    )
+  }
+
+  @Test
+  fun sync() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenMethodLibraryBookApi.Sync::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenMethodLibraryBookApi.Sync" +
+        " has invalid method: SYNC.",
+    )
+  }
+}

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenMethodRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenMethodRestEndpointTemplateTest.kt
@@ -33,9 +33,9 @@ internal class BrokenMethodRestEndpointTemplateTest {
   @Test
   fun sync() {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenMethodLibraryBookApi.Sync::class)
+      RestEndpointTemplate.parse(BrokenMethodLibraryBookApi.UnsupportedMethod::class)
     }.shouldHaveMessage(
-      "REST endpoint kairo.restFeature.BrokenMethodLibraryBookApi.Sync" +
+      "REST endpoint kairo.restFeature.BrokenMethodLibraryBookApi.UnsupportedMethod" +
         " has invalid method: SYNC.",
     )
   }

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenParamLibraryBookApi.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenParamLibraryBookApi.kt
@@ -13,7 +13,7 @@ internal object BrokenParamLibraryBookApi {
   @RestEndpoint.Accept("application/json")
   internal data class NonParamConstructorParameter(
     val shouldNotBeHere: String,
-  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+  ) : RestEndpoint<Nothing, List<LibraryBookRep>>()
 
   @RestEndpoint.Method("POST")
   @RestEndpoint.Path("/library/library-books/:body")
@@ -28,7 +28,7 @@ internal object BrokenParamLibraryBookApi {
   @RestEndpoint.ContentType("application/json")
   @RestEndpoint.Accept("application/json")
   internal data class BodyAsQueryParam(
-    @PathParam override val body: LibraryBookRep.Creator,
+    @QueryParam override val body: LibraryBookRep.Creator,
   ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
 
   @RestEndpoint.Method("GET")
@@ -36,19 +36,19 @@ internal object BrokenParamLibraryBookApi {
   @RestEndpoint.Accept("application/json")
   internal data class PathParamMarkedAsQueryParam(
     @QueryParam val libraryBookId: KairoId,
-  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+  ) : RestEndpoint<Nothing, LibraryBookRep?>()
 
   @RestEndpoint.Method("GET")
   @RestEndpoint.Path("/library/library-books")
   @RestEndpoint.Accept("application/json")
   internal data class QueryParamMarkedAsPathParam(
     @PathParam val isbn: String,
-  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+  ) : RestEndpoint<Nothing, List<LibraryBookRep>>()
 
   @RestEndpoint.Method("GET")
   @RestEndpoint.Path("/library/library-books/:libraryBookId")
   @RestEndpoint.Accept("application/json")
   internal data class ParamIsPathAndQuery(
     @PathParam @QueryParam val libraryBookId: KairoId,
-  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+  ) : RestEndpoint<Nothing, LibraryBookRep?>()
 }

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenParamLibraryBookApi.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenParamLibraryBookApi.kt
@@ -1,0 +1,54 @@
+package kairo.restFeature
+
+import kairo.id.KairoId
+
+/**
+ * This API is for [BrokenParamRestEndpointTemplateTest]
+ * which tests cases where the [RestEndpoint.PathParam] and [RestEndpoint.QueryParam] annotations
+ * are used in unexpected or unsupported ways.
+ */
+internal object BrokenParamLibraryBookApi {
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("/library/library-books")
+  @RestEndpoint.Accept("application/json")
+  internal data class NonParamConstructorParameter(
+    val shouldNotBeHere: String,
+  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+
+  @RestEndpoint.Method("POST")
+  @RestEndpoint.Path("/library/library-books/:body")
+  @RestEndpoint.ContentType("application/json")
+  @RestEndpoint.Accept("application/json")
+  internal data class BodyAsPathParam(
+    @PathParam override val body: LibraryBookRep.Creator,
+  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+
+  @RestEndpoint.Method("POST")
+  @RestEndpoint.Path("/library/library-books")
+  @RestEndpoint.ContentType("application/json")
+  @RestEndpoint.Accept("application/json")
+  internal data class BodyAsQueryParam(
+    @PathParam override val body: LibraryBookRep.Creator,
+  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("/library/library-books/:libraryBookId")
+  @RestEndpoint.Accept("application/json")
+  internal data class PathParamMarkedAsQueryParam(
+    @QueryParam val libraryBookId: KairoId,
+  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("/library/library-books")
+  @RestEndpoint.Accept("application/json")
+  internal data class QueryParamMarkedAsPathParam(
+    @PathParam val isbn: String,
+  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("/library/library-books/:libraryBookId")
+  @RestEndpoint.Accept("application/json")
+  internal data class ParamIsPathAndQuery(
+    @PathParam @QueryParam val libraryBookId: KairoId,
+  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+}

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenParamRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenParamRestEndpointTemplateTest.kt
@@ -1,0 +1,72 @@
+package kairo.restFeature
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.throwable.shouldHaveMessage
+import org.junit.jupiter.api.Test
+
+/**
+ * This test uses [BrokenParamLibraryBookApi]
+ * to test cases where the [RestEndpoint.PathParam] and [RestEndpoint.QueryParam] annotations
+ * are used in unexpected or unsupported ways.
+ */
+internal class BrokenParamRestEndpointTemplateTest {
+  @Test
+  fun nonParamConstructorParameter() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenParamLibraryBookApi.NonParamConstructorParameter::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenParamLibraryBookApi.NonParamConstructorParameter" +
+        " param must be path or query: shouldNotBeHere.",
+    )
+  }
+
+  @Test
+  fun bodyAsPathParam() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenParamLibraryBookApi.BodyAsPathParam::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenParamLibraryBookApi.BodyAsPathParam" +
+        " body cannot be param.",
+    )
+  }
+
+  @Test
+  fun bodyAsQueryParam() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenParamLibraryBookApi.BodyAsQueryParam::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenParamLibraryBookApi.BodyAsQueryParam" +
+        " body cannot be param.",
+    )
+  }
+
+  @Test
+  fun pathParamMarkedAsQueryParam() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenParamLibraryBookApi.PathParamMarkedAsQueryParam::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenParamLibraryBookApi.PathParamMarkedAsQueryParam" +
+        " path is invalid. Path param in path but not in constructor: libraryBookId.",
+    )
+  }
+
+  @Test
+  fun queryParamMarkedAsPathParam() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenParamLibraryBookApi.QueryParamMarkedAsPathParam::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenParamLibraryBookApi.QueryParamMarkedAsPathParam" +
+        " path is invalid. Path param in constructor but not in path: isbn.",
+    )
+  }
+
+  @Test
+  fun paramIsPathAndQuery() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenParamLibraryBookApi.ParamIsPathAndQuery::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenParamLibraryBookApi.ParamIsPathAndQuery" +
+        " param cannot be both path and query: libraryBookId.",
+    )
+  }
+}

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenPathLibraryBookApi.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenPathLibraryBookApi.kt
@@ -1,0 +1,71 @@
+package kairo.restFeature
+
+import kairo.id.KairoId
+
+/**
+ * This API is for [BrokenPathRestEndpointTemplateTest]
+ * which tests cases where the [RestEndpoint.Path] annotation
+ * is used in unexpected or unsupported ways.
+ */
+internal object BrokenPathLibraryBookApi {
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Accept("application/json")
+  internal data object MissingPath : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("")
+  @RestEndpoint.Accept("application/json")
+  internal data object EmptyPath : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("library/library-books")
+  @RestEndpoint.Accept("application/json")
+  internal data object PathMissingLeadingSlash : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("/library/libraryBooks/:libraryBookId")
+  @RestEndpoint.Accept("application/json")
+  internal data class InvalidConstantPathComponent(
+    @PathParam val libraryBookId: KairoId,
+  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("/library/library-books/:library-book-id")
+  @RestEndpoint.Accept("application/json")
+  internal data class InvalidParamPathComponent(
+    @PathParam val libraryBookId: KairoId,
+  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("/library/library-books/:libraryBookId")
+  @RestEndpoint.Accept("application/json")
+  internal data class NullablePathParam(
+    @PathParam val libraryBookId: KairoId?,
+  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("/library/library-books/:libraryBookId")
+  @RestEndpoint.Accept("application/json")
+  internal data class OptionalPathParam(
+    @PathParam val libraryBookId: KairoId = KairoId("library_book", "2eDS1sMt"),
+  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("/library/library-books/:libraryBookId/:libraryBookId")
+  @RestEndpoint.Accept("application/json")
+  internal data class DuplicatePathParamInPath(
+    @PathParam val libraryBookId: KairoId,
+  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("/library/library-books/:libraryBookId")
+  @RestEndpoint.Accept("application/json")
+  internal data object PathParamInPathButNotInConstructor : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("/library/library-books")
+  @RestEndpoint.Accept("application/json")
+  internal data class PathParamInConstructorButNotInPath(
+    @PathParam val libraryBookId: KairoId,
+  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+}

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenPathLibraryBookApi.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenPathLibraryBookApi.kt
@@ -10,62 +10,62 @@ import kairo.id.KairoId
 internal object BrokenPathLibraryBookApi {
   @RestEndpoint.Method("GET")
   @RestEndpoint.Accept("application/json")
-  internal data object MissingPath : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+  internal data object MissingPath : RestEndpoint<Nothing, List<LibraryBookRep>>()
 
   @RestEndpoint.Method("GET")
   @RestEndpoint.Path("")
   @RestEndpoint.Accept("application/json")
-  internal data object EmptyPath : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+  internal data object EmptyPath : RestEndpoint<Nothing, List<LibraryBookRep>>()
 
   @RestEndpoint.Method("GET")
   @RestEndpoint.Path("library/library-books")
   @RestEndpoint.Accept("application/json")
-  internal data object PathMissingLeadingSlash : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+  internal data object PathMissingLeadingSlash : RestEndpoint<Nothing, List<LibraryBookRep>>()
 
   @RestEndpoint.Method("GET")
   @RestEndpoint.Path("/library/libraryBooks/:libraryBookId")
   @RestEndpoint.Accept("application/json")
-  internal data class InvalidConstantPathComponent(
+  internal data class MalformedConstantPathComponent(
     @PathParam val libraryBookId: KairoId,
-  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+  ) : RestEndpoint<Nothing, LibraryBookRep?>()
 
   @RestEndpoint.Method("GET")
   @RestEndpoint.Path("/library/library-books/:library-book-id")
   @RestEndpoint.Accept("application/json")
-  internal data class InvalidParamPathComponent(
+  internal data class MalformedParamPathComponent(
     @PathParam val libraryBookId: KairoId,
-  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+  ) : RestEndpoint<Nothing, LibraryBookRep?>()
 
   @RestEndpoint.Method("GET")
   @RestEndpoint.Path("/library/library-books/:libraryBookId")
   @RestEndpoint.Accept("application/json")
   internal data class NullablePathParam(
     @PathParam val libraryBookId: KairoId?,
-  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+  ) : RestEndpoint<Nothing, LibraryBookRep>()
 
   @RestEndpoint.Method("GET")
   @RestEndpoint.Path("/library/library-books/:libraryBookId")
   @RestEndpoint.Accept("application/json")
   internal data class OptionalPathParam(
     @PathParam val libraryBookId: KairoId = KairoId("library_book", "2eDS1sMt"),
-  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+  ) : RestEndpoint<Nothing, LibraryBookRep?>()
 
   @RestEndpoint.Method("GET")
   @RestEndpoint.Path("/library/library-books/:libraryBookId/:libraryBookId")
   @RestEndpoint.Accept("application/json")
   internal data class DuplicatePathParamInPath(
     @PathParam val libraryBookId: KairoId,
-  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+  ) : RestEndpoint<Nothing, LibraryBookRep?>()
 
   @RestEndpoint.Method("GET")
   @RestEndpoint.Path("/library/library-books/:libraryBookId")
   @RestEndpoint.Accept("application/json")
-  internal data object PathParamInPathButNotInConstructor : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+  internal data object PathParamInPathButNotInConstructor : RestEndpoint<Nothing, LibraryBookRep?>()
 
   @RestEndpoint.Method("GET")
   @RestEndpoint.Path("/library/library-books")
   @RestEndpoint.Accept("application/json")
   internal data class PathParamInConstructorButNotInPath(
     @PathParam val libraryBookId: KairoId,
-  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+  ) : RestEndpoint<Nothing, LibraryBookRep?>()
 }

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenPathRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenPathRestEndpointTemplateTest.kt
@@ -41,31 +41,31 @@ internal class BrokenPathRestEndpointTemplateTest {
   }
 
   @Test
-  fun invalidConstantPathComponent() {
+  fun malformedConstantPathComponent() {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.InvalidConstantPathComponent::class)
+      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.MalformedConstantPathComponent::class)
     }.shouldHaveMessage(
-      "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.InvalidConstantPathComponent" +
+      "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.MalformedConstantPathComponent" +
         " path is invalid. Path constants must be kebab case: libraryBooks.",
     )
   }
 
   @Test
-  fun invalidPathConstantComponent() {
+  fun malformedPathConstantComponent() {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.InvalidConstantPathComponent::class)
+      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.MalformedConstantPathComponent::class)
     }.shouldHaveMessage(
-      "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.InvalidConstantPathComponent" +
+      "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.MalformedConstantPathComponent" +
         " path is invalid. Path constants must be kebab case: libraryBooks.",
     )
   }
 
   @Test
-  fun invalidParamPathComponent() {
+  fun malformedParamPathComponent() {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.InvalidParamPathComponent::class)
+      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.MalformedParamPathComponent::class)
     }.shouldHaveMessage(
-      "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.InvalidParamPathComponent" +
+      "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.MalformedParamPathComponent" +
         " path is invalid. Path params must be camel case: library-book-id.",
     )
   }

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenPathRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenPathRestEndpointTemplateTest.kt
@@ -1,0 +1,122 @@
+package kairo.restFeature
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.throwable.shouldHaveMessage
+import org.junit.jupiter.api.Test
+
+/**
+ * This test uses [BrokenPathLibraryBookApi]
+ * to test cases where the [RestEndpoint.Path] annotation
+ * is used in unexpected or unsupported ways.
+ */
+internal class BrokenPathRestEndpointTemplateTest {
+  @Test
+  fun missingMethod() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.MissingPath::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.MissingPath" +
+        " is missing @Path.",
+    )
+  }
+
+  @Test
+  fun emptyMethod() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.EmptyPath::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.EmptyPath" +
+        " path must start with a slash: .",
+    )
+  }
+
+  @Test
+  fun pathMissingLeadingSlash() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.PathMissingLeadingSlash::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.PathMissingLeadingSlash" +
+        " path must start with a slash: library/library-books.",
+    )
+  }
+
+  @Test
+  fun invalidConstantPathComponent() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.InvalidConstantPathComponent::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.InvalidConstantPathComponent" +
+        " path is invalid. Path constants must be kebab case: libraryBooks.",
+    )
+  }
+
+  @Test
+  fun invalidPathConstantComponent() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.InvalidConstantPathComponent::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.InvalidConstantPathComponent" +
+        " path is invalid. Path constants must be kebab case: libraryBooks.",
+    )
+  }
+
+  @Test
+  fun invalidParamPathComponent() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.InvalidParamPathComponent::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.InvalidParamPathComponent" +
+        " path is invalid. Path params must be camel case: library-book-id.",
+    )
+  }
+
+  @Test
+  fun nullablePathParam() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.NullablePathParam::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.NullablePathParam" +
+        " path is invalid. Path param must not be nullable: libraryBookId.",
+    )
+  }
+
+  @Test
+  fun optionalPathParam() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.OptionalPathParam::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.OptionalPathParam" +
+        " path is invalid. Path param must not be optional: libraryBookId.",
+    )
+  }
+
+  @Test
+  fun duplicatePathParamInPath() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.DuplicatePathParamInPath::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.DuplicatePathParamInPath" +
+        " path is invalid. Duplicate path param in path: libraryBookId.",
+    )
+  }
+
+  @Test
+  fun pathParamInPathButNotInConstructor() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.PathParamInPathButNotInConstructor::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.PathParamInPathButNotInConstructor" +
+        " path is invalid. Path param in path but not in constructor: libraryBookId.",
+    )
+  }
+
+  @Test
+  fun pathParamInConstructorButNotInPath() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.PathParamInConstructorButNotInPath::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.PathParamInConstructorButNotInPath" +
+        " path is invalid. Path param in constructor but not in path: libraryBookId.",
+    )
+  }
+}

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenRestEndpointTemplateTest.kt
@@ -1,0 +1,31 @@
+package kairo.restFeature
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.throwable.shouldHaveMessage
+import org.junit.jupiter.api.Test
+
+/**
+ * This test uses [BrokenLibraryBookApi]
+ * to test simple invalid cases not related to a particular [RestEndpoint] annotation.
+ */
+internal class BrokenRestEndpointTemplateTest {
+  @Test
+  fun notDataClass() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenLibraryBookApi.NotDataClass::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenLibraryBookApi.NotDataClass" +
+        " must be a data class or data object.",
+    )
+  }
+
+  @Test
+  fun notDataObject() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenLibraryBookApi.NotDataObject::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenLibraryBookApi.NotDataObject" +
+        " must be a data class or data object.",
+    )
+  }
+}

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenTypeLibraryBookApi.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenTypeLibraryBookApi.kt
@@ -1,0 +1,41 @@
+package kairo.restFeature
+
+import kairo.id.KairoId
+
+/**
+ * This API is for [BrokenRestEndpointTemplateTest]
+ * which tests invalid cases related to types within [RestEndpoint].
+ */
+internal object BrokenTypeLibraryBookApi {
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("/library/library-books/:libraryBookId")
+  @RestEndpoint.ContentType("application/json")
+  @RestEndpoint.Accept("application/json")
+  internal data class GetWithBodyNotProvided(
+    @PathParam val libraryBookId: KairoId,
+  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep?>()
+
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("/library/library-books/:libraryBookId")
+  @RestEndpoint.ContentType("application/json")
+  @RestEndpoint.Accept("application/json")
+  internal data class GetWithBodyProvided(
+    @PathParam val libraryBookId: KairoId,
+    override val body: LibraryBookRep.Creator,
+  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep?>()
+
+  @RestEndpoint.Method("POST")
+  @RestEndpoint.Path("/library/library-books/:libraryBookId")
+  @RestEndpoint.Accept("application/json")
+  internal data class PostWithoutBodyNotProvided(
+    @PathParam val libraryBookId: KairoId,
+  ) : RestEndpoint<Nothing, LibraryBookRep?>()
+
+  @RestEndpoint.Method("POST")
+  @RestEndpoint.Path("/library/library-books/:libraryBookId")
+  @RestEndpoint.Accept("application/json")
+  internal data class PostWithoutBodyProvided(
+    @PathParam val libraryBookId: KairoId,
+    override val body: Nothing,
+  ) : RestEndpoint<Nothing, LibraryBookRep?>()
+}

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenTypeRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenTypeRestEndpointTemplateTest.kt
@@ -15,7 +15,7 @@ internal class BrokenTypeRestEndpointTemplateTest {
       RestEndpointTemplate.parse(BrokenTypeLibraryBookApi.GetWithBodyNotProvided::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenTypeLibraryBookApi.GetWithBodyNotProvided" +
-        " has method HttpMethod(value=GET) but specifies a body.",
+        " has method GET but specifies a body.",
     )
   }
 
@@ -25,7 +25,7 @@ internal class BrokenTypeRestEndpointTemplateTest {
       RestEndpointTemplate.parse(BrokenTypeLibraryBookApi.GetWithBodyProvided::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenTypeLibraryBookApi.GetWithBodyProvided" +
-        " has method HttpMethod(value=GET) but specifies a body.",
+        " has method GET but specifies a body.",
     )
   }
 
@@ -35,7 +35,7 @@ internal class BrokenTypeRestEndpointTemplateTest {
       RestEndpointTemplate.parse(BrokenTypeLibraryBookApi.PostWithoutBodyProvided::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenTypeLibraryBookApi.PostWithoutBodyProvided" +
-        " has method HttpMethod(value=POST) but specifies a body.",
+        " has method POST but specifies a body.",
     )
   }
 
@@ -45,7 +45,7 @@ internal class BrokenTypeRestEndpointTemplateTest {
       RestEndpointTemplate.parse(BrokenTypeLibraryBookApi.PostWithoutBodyNotProvided::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenTypeLibraryBookApi.PostWithoutBodyNotProvided" +
-        " has method HttpMethod(value=POST) but specifies a body.",
+        " has method POST but specifies a body.",
     )
   }
 }

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenTypeRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenTypeRestEndpointTemplateTest.kt
@@ -1,0 +1,51 @@
+package kairo.restFeature
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.throwable.shouldHaveMessage
+import org.junit.jupiter.api.Test
+
+/**
+ * This test uses [BrokenLibraryBookApi]
+ * to test invalid cases related to types within [RestEndpoint].
+ */
+internal class BrokenTypeRestEndpointTemplateTest {
+  @Test
+  fun getWithBodyNotProvided() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenTypeLibraryBookApi.GetWithBodyNotProvided::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenTypeLibraryBookApi.GetWithBodyNotProvided" +
+        " has method HttpMethod(value=GET) but specifies a body.",
+    )
+  }
+
+  @Test
+  fun getWithBodyProvided() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenTypeLibraryBookApi.GetWithBodyProvided::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenTypeLibraryBookApi.GetWithBodyProvided" +
+        " has method HttpMethod(value=GET) but specifies a body.",
+    )
+  }
+
+  @Test
+  fun postWithoutBodyNotProvided() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenTypeLibraryBookApi.PostWithoutBodyProvided::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenTypeLibraryBookApi.PostWithoutBodyProvided" +
+        " has method HttpMethod(value=POST) but specifies a body.",
+    )
+  }
+
+  @Test
+  fun postWithoutBodyProvided() {
+    shouldThrow<IllegalArgumentException> {
+      RestEndpointTemplate.parse(BrokenTypeLibraryBookApi.PostWithoutBodyNotProvided::class)
+    }.shouldHaveMessage(
+      "REST endpoint kairo.restFeature.BrokenTypeLibraryBookApi.PostWithoutBodyNotProvided" +
+        " has method HttpMethod(value=POST) but specifies a body.",
+    )
+  }
+}

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/LibraryBookRep.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/LibraryBookRep.kt
@@ -1,0 +1,18 @@
+package kairo.restFeature
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import kairo.id.KairoId
+
+internal data class LibraryBookRep(
+  val id: KairoId,
+  val title: String,
+) {
+  internal data class Creator(
+    val title: String,
+  )
+
+  @JsonInclude(value = JsonInclude.Include.NON_NULL)
+  internal data class Update(
+    val title: String? = null,
+  )
+}

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/TypicalLibraryBookApi.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/TypicalLibraryBookApi.kt
@@ -1,0 +1,59 @@
+package kairo.restFeature
+
+import kairo.id.KairoId
+
+/**
+ * This API is for [TypicalRestEndpointTemplateTest] which tests typical (happy path) cases.
+ */
+internal object TypicalLibraryBookApi {
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("/library/library-books/:libraryBookId")
+  @RestEndpoint.Accept("application/json")
+  internal data class Get(
+    @PathParam val libraryBookId: KairoId,
+  ) : RestEndpoint<Nothing, LibraryBookRep?>()
+
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("/library/library-books")
+  @RestEndpoint.Accept("application/json")
+  internal data object ListAll : RestEndpoint<Nothing, List<LibraryBookRep>>()
+
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("/library/library-books")
+  @RestEndpoint.Accept("application/json")
+  internal data class SearchByIsbn(
+    @QueryParam val isbn: String,
+  ) : RestEndpoint<Nothing, List<LibraryBookRep>>()
+
+  @RestEndpoint.Method("GET")
+  @RestEndpoint.Path("/library/library-books")
+  @RestEndpoint.Accept("application/json")
+  internal data class SearchByText(
+    @QueryParam val title: String?,
+    @QueryParam val author: String?,
+  ) : RestEndpoint<Nothing, List<LibraryBookRep>>()
+
+  @RestEndpoint.Method("POST")
+  @RestEndpoint.Path("/library/library-books")
+  @RestEndpoint.ContentType("application/json")
+  @RestEndpoint.Accept("application/json")
+  internal data class Create(
+    override val body: LibraryBookRep.Creator,
+  ) : RestEndpoint<LibraryBookRep.Creator, LibraryBookRep>()
+
+  @RestEndpoint.Method("PATCH")
+  @RestEndpoint.Path("/library/library-books/:libraryBookId")
+  @RestEndpoint.ContentType("application/json")
+  @RestEndpoint.Accept("application/json")
+  internal data class Update(
+    @PathParam val libraryBookId: KairoId,
+    override val body: LibraryBookRep.Update,
+  ) : RestEndpoint<LibraryBookRep.Update, LibraryBookRep>()
+
+  @RestEndpoint.Method("DELETE")
+  @RestEndpoint.Path("/library/library-books/:libraryBookId")
+  @RestEndpoint.Accept("application/json")
+  internal data class Delete(
+    @PathParam val libraryBookId: KairoId,
+  ) : RestEndpoint<Nothing, LibraryBookRep>()
+}

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/TypicalRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/TypicalRestEndpointTemplateTest.kt
@@ -1,0 +1,138 @@
+package kairo.restFeature
+
+import io.kotest.matchers.shouldBe
+import io.ktor.http.ContentType
+import io.ktor.http.HttpMethod
+import org.junit.jupiter.api.Test
+
+/**
+ * This test uses [TypicalLibraryBookApi] to test typical (happy path) cases.
+ */
+internal class TypicalRestEndpointTemplateTest {
+  @Test
+  fun get() {
+    RestEndpointTemplate.parse(TypicalLibraryBookApi.Get::class)
+      .shouldBe(
+        RestEndpointTemplate(
+          method = HttpMethod.Get,
+          path = RestEndpointPath.of(
+            RestEndpointPath.Component.Constant("library"),
+            RestEndpointPath.Component.Constant("library-books"),
+            RestEndpointPath.Component.Param("libraryBookId"),
+          ),
+          query = RestEndpointQuery.of(),
+          contentType = null,
+          accept = ContentType.Application.Json,
+        ),
+      )
+  }
+
+  @Test
+  fun listAll() {
+    RestEndpointTemplate.parse(TypicalLibraryBookApi.ListAll::class)
+      .shouldBe(
+        RestEndpointTemplate(
+          method = HttpMethod.Get,
+          path = RestEndpointPath.of(
+            RestEndpointPath.Component.Constant("library"),
+            RestEndpointPath.Component.Constant("library-books"),
+          ),
+          query = RestEndpointQuery.of(),
+          contentType = null,
+          accept = ContentType.Application.Json,
+        ),
+      )
+  }
+
+  @Test
+  fun searchByIsbn() {
+    RestEndpointTemplate.parse(TypicalLibraryBookApi.SearchByIsbn::class)
+      .shouldBe(
+        RestEndpointTemplate(
+          method = HttpMethod.Get,
+          path = RestEndpointPath.of(
+            RestEndpointPath.Component.Constant("library"),
+            RestEndpointPath.Component.Constant("library-books"),
+          ),
+          query = RestEndpointQuery.of(
+            RestEndpointQuery.Param("isbn", required = true),
+          ),
+          contentType = null,
+          accept = ContentType.Application.Json,
+        ),
+      )
+  }
+
+  @Test
+  fun searchByTitle() {
+    RestEndpointTemplate.parse(TypicalLibraryBookApi.SearchByText::class)
+      .shouldBe(
+        RestEndpointTemplate(
+          method = HttpMethod.Get,
+          path = RestEndpointPath.of(
+            RestEndpointPath.Component.Constant("library"),
+            RestEndpointPath.Component.Constant("library-books"),
+          ),
+          query = RestEndpointQuery.of(
+            RestEndpointQuery.Param("title", required = false),
+            RestEndpointQuery.Param("author", required = false),
+          ),
+          contentType = null,
+          accept = ContentType.Application.Json,
+        ),
+      )
+  }
+
+  @Test
+  fun create() {
+    RestEndpointTemplate.parse(TypicalLibraryBookApi.Create::class)
+      .shouldBe(
+        RestEndpointTemplate(
+          method = HttpMethod.Post,
+          path = RestEndpointPath.of(
+            RestEndpointPath.Component.Constant("library"),
+            RestEndpointPath.Component.Constant("library-books"),
+          ),
+          query = RestEndpointQuery.of(),
+          contentType = ContentType.Application.Json,
+          accept = ContentType.Application.Json,
+        ),
+      )
+  }
+
+  @Test
+  fun update() {
+    RestEndpointTemplate.parse(TypicalLibraryBookApi.Update::class)
+      .shouldBe(
+        RestEndpointTemplate(
+          method = HttpMethod.Patch,
+          path = RestEndpointPath.of(
+            RestEndpointPath.Component.Constant("library"),
+            RestEndpointPath.Component.Constant("library-books"),
+            RestEndpointPath.Component.Param("libraryBookId"),
+          ),
+          query = RestEndpointQuery.of(),
+          contentType = ContentType.Application.Json,
+          accept = ContentType.Application.Json,
+        ),
+      )
+  }
+
+  @Test
+  fun delete() {
+    RestEndpointTemplate.parse(TypicalLibraryBookApi.Delete::class)
+      .shouldBe(
+        RestEndpointTemplate(
+          method = HttpMethod.Delete,
+          path = RestEndpointPath.of(
+            RestEndpointPath.Component.Constant("library"),
+            RestEndpointPath.Component.Constant("library-books"),
+            RestEndpointPath.Component.Param("libraryBookId"),
+          ),
+          query = RestEndpointQuery.of(),
+          contentType = null,
+          accept = ContentType.Application.Json,
+        ),
+      )
+  }
+}

--- a/kairo-server/src/main/kotlin/kairo/server/Server.kt
+++ b/kairo-server/src/main/kotlin/kairo/server/Server.kt
@@ -24,7 +24,6 @@ public abstract class Server {
    * If [shutdownHook] is passed, [shutDown] will be automatically called when the JVM shuts down.
    * If [wait] is passed, this call won't return until the JVM is terminated.
    */
-  @Suppress("CognitiveComplexMethod", "LongMethod")
   public fun start(shutdownHook: Boolean = true, wait: Boolean = true) {
     lock.withLock {
       if (injector != null) {

--- a/kairo-server/src/test/kotlin/kairo/server/ServerTest.kt
+++ b/kairo-server/src/test/kotlin/kairo/server/ServerTest.kt
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test
  * Specifically, it doesn't test shutdown hooks, the wait flag
  */
 internal class ServerTest {
-  @Suppress("LongMethod")
   @Test
   fun server() {
     class TestFeature : Feature() {


### PR DESCRIPTION
### Summary

This PR is mostly tests. It introduces REST endpoint templates, which will be used for Ktor routing and logging.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
