### PR TITLE
Create bindRestEndpoint helper

### DIFF
--- a/kairo-rest-feature/README.md
+++ b/kairo-rest-feature/README.md
@@ -117,7 +117,7 @@ They are intended to be grouped together using Kotlin singleton objects.
 ```kotlin
 // src/main/kotlin/yourPackage/feature/library/book/LibraryBookHandler.kt
 
-object OrganizationHandler {
+object LibraryBookHandler {
   class Get @Inject constructor() : RestHandler<LibraryBookApi.Get>()
 
   class ListAll @Inject constructor() : RestHandler<LibraryBookApi.ListAll>()

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/bindRestEndpoint.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/bindRestEndpoint.kt
@@ -1,0 +1,15 @@
+package kairo.restFeature
+
+import com.google.inject.PrivateBinder
+import com.google.inject.multibindings.Multibinder
+import kairo.dependencyInjection.type
+
+/**
+ * Binding REST endpoints uses a [Multibinder],
+ * which allows multiple instances to be bound separately but injected together as a set.
+ */
+public inline fun <reified Handler : RestHandler<*>> PrivateBinder.bindRestEndpoint() {
+  val multibinder = Multibinder.newSetBinder(this, type<RestHandler<*>>())
+  multibinder.addBinding().to(Handler::class.java)
+  expose(type<Set<RestHandler<*>>>())
+}


### PR DESCRIPTION
### Summary

This simple PR introduces a `bindRestEndpoint()` helper function for binding REST endpoints within other Features.

I also took this opportunity to update the REST Feature README.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
