### PR TITLE
Implement automatic endpoint reading

### DIFF
--- a/kairo-rest-feature/build.gradle.kts
+++ b/kairo-rest-feature/build.gradle.kts
@@ -7,12 +7,12 @@ dependencies {
   api(project(":kairo-feature"))
   implementation(project(":kairo-logging"))
   implementation(project(":kairo-reflect"))
+  implementation(project(":kairo-serialization"))
 
   implementation(libs.ktorServerCio)
   implementation(libs.ktorServerCore)
 
   testImplementation(project(":kairo-id-feature"))
   testImplementation(project(":kairo-logging:testing"))
-  testImplementation(project(":kairo-serialization"))
   testImplementation(project(":testing"))
 }

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/DataClassRestEndpointReader.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/DataClassRestEndpointReader.kt
@@ -1,0 +1,43 @@
+package kairo.restFeature
+
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.routing.RoutingCall
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+import kotlin.reflect.KParameter
+import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.full.valueParameters
+
+private val logger: KLogger = KotlinLogging.logger {}
+
+/**
+ * This is the typical case for [RestEndpointReader].
+ * We use JVM reflection to inspect the [RestEndpoint] class
+ * in order to determine how to get the arguments from the [RoutingCall]
+ * call the primary constructor of the data class.
+ */
+internal class DataClassRestEndpointReader<out Endpoint : RestEndpoint<*, *>>(
+  endpoint: KClass<Endpoint>,
+) : RestEndpointReader<Endpoint>() {
+
+  private val constructor: KFunction<Endpoint> =
+    checkNotNull(endpoint.primaryConstructor)
+
+  override suspend fun endpoint(call: RoutingCall): Endpoint {
+    logger.debug { "Creating data class." }
+    val arguments = arguments(call)
+    logger.debug { "Arguments: $arguments." }
+    return constructor.callBy(arguments.mapValues { (_, argument) -> argument.read() }.filterValues { it != null })
+  }
+
+  private fun arguments(call: ApplicationCall): Map<KParameter, RestEndpointArgument> {
+    return constructor.valueParameters.associateWith { param ->
+      if (param.name == RestEndpoint<*, *>::body.name) {
+        return@associateWith RestEndpointArgument.Body(call, param)
+      }
+      return@associateWith RestEndpointArgument.Param(call, param)
+    }
+  }
+}

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/DataClassRestEndpointReader.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/DataClassRestEndpointReader.kt
@@ -28,7 +28,7 @@ internal class DataClassRestEndpointReader<out Endpoint : RestEndpoint<*, *>>(
     logger.debug { "Creating data class." }
     val arguments = arguments(call)
     logger.debug { "Arguments: $arguments." }
-    return constructor.callBy(arguments.mapValues { (_, argument) -> argument.read() }.filterValues { it != null })
+    return constructor.callBy(arguments.mapValues { (_, argument) -> argument.read() })
   }
 
   private fun arguments(call: ApplicationCall): Map<KParameter, RestEndpointArgument> {

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/DataClassRestEndpointReader.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/DataClassRestEndpointReader.kt
@@ -16,7 +16,7 @@ private val logger: KLogger = KotlinLogging.logger {}
  * This is the typical case for [RestEndpointReader].
  * We use JVM reflection to inspect the [RestEndpoint] class
  * in order to determine how to get the arguments from the [RoutingCall]
- * call the primary constructor of the data class.
+ * to call the primary constructor of the data class.
  */
 internal class DataClassRestEndpointReader<out Endpoint : RestEndpoint<*, *>>(
   endpoint: KClass<Endpoint>,

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/DataClassRestEndpointReader.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/DataClassRestEndpointReader.kt
@@ -21,7 +21,6 @@ private val logger: KLogger = KotlinLogging.logger {}
 internal class DataClassRestEndpointReader<out Endpoint : RestEndpoint<*, *>>(
   endpoint: KClass<Endpoint>,
 ) : RestEndpointReader<Endpoint>() {
-
   private val constructor: KFunction<Endpoint> =
     checkNotNull(endpoint.primaryConstructor)
 

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/DataObjectRestEndpointReader.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/DataObjectRestEndpointReader.kt
@@ -1,0 +1,24 @@
+package kairo.restFeature
+
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.server.routing.RoutingCall
+import kotlin.reflect.KClass
+
+private val logger: KLogger = KotlinLogging.logger {}
+
+/**
+ * Some [RestEndpoint]s are singleton objects (they will be data objects).
+ * This makes our job easy, since we just return the singleton!
+ */
+internal class DataObjectRestEndpointReader<out Endpoint : RestEndpoint<*, *>>(
+  endpoint: KClass<Endpoint>,
+) : RestEndpointReader<Endpoint>() {
+  private val objectInstance: Endpoint =
+    checkNotNull(endpoint.objectInstance)
+
+  override suspend fun endpoint(call: RoutingCall): Endpoint {
+    logger.debug { "Using object instance." }
+    return objectInstance
+  }
+}

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointArgument.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointArgument.kt
@@ -1,0 +1,37 @@
+package kairo.restFeature
+
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.receiveStream
+import kotlin.reflect.KParameter
+import kotlin.reflect.jvm.javaType
+
+internal sealed class RestEndpointArgument(
+  private val call: ApplicationCall,
+  protected val param: KParameter,
+) {
+  suspend fun read(): Any? = read(call)
+
+  protected abstract suspend fun read(call: ApplicationCall): Any?
+
+  internal class Body(
+    call: ApplicationCall,
+    param: KParameter,
+  ) : RestEndpointArgument(call, param) {
+    override suspend fun read(call: ApplicationCall): Any {
+      return ktorObjectMapper.readValue(call.receiveStream(), ktorObjectMapper.constructType(param.type.javaType))
+    }
+  }
+
+  internal class Param(
+    call: ApplicationCall,
+    param: KParameter,
+  ) : RestEndpointArgument(call, param) {
+    private val name: String = checkNotNull(param.name)
+
+    override suspend fun read(call: ApplicationCall): Any? {
+      val parameters = call.parameters.getAll(name) ?: return null
+      val parameter = parameters.single() // Lists are not supported yet.
+      return ktorObjectMapper.convertValue(parameter, ktorObjectMapper.constructType(param.type.javaType))
+    }
+  }
+}

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointArgument.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointArgument.kt
@@ -18,7 +18,7 @@ internal sealed class RestEndpointArgument(
     param: KParameter,
   ) : RestEndpointArgument(call, param) {
     override suspend fun read(call: ApplicationCall): Any {
-      return ktorObjectMapper.readValue(call.receiveStream(), ktorObjectMapper.constructType(param.type.javaType))
+      return ktorMapper.readValue(call.receiveStream(), ktorMapper.constructType(param.type.javaType))
     }
   }
 
@@ -31,7 +31,7 @@ internal sealed class RestEndpointArgument(
     override suspend fun read(call: ApplicationCall): Any? {
       val parameters = call.parameters.getAll(name) ?: return null
       val parameter = parameters.single() // Lists are not supported yet.
-      return ktorObjectMapper.convertValue(parameter, ktorObjectMapper.constructType(param.type.javaType))
+      return ktorMapper.convertValue(parameter, ktorMapper.constructType(param.type.javaType))
     }
   }
 }

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointReader.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointReader.kt
@@ -1,0 +1,30 @@
+package kairo.restFeature
+
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.server.routing.RoutingCall
+import kotlin.reflect.KClass
+
+private val logger: KLogger = KotlinLogging.logger {}
+
+/**
+ * [RestEndpointReader] is responsible for deriving an [Endpoint] instance from a [RoutingCall].
+ * Doing this dynamically at runtime involves some nontrivial JVM reflection magic,
+ * but it's a huge win for reducing boilerplate.
+ */
+internal abstract class RestEndpointReader<out Endpoint : RestEndpoint<*, *>> {
+  abstract suspend fun endpoint(call: RoutingCall): Endpoint
+
+  internal companion object {
+    fun <Endpoint : RestEndpoint<*, *>> from(endpoint: KClass<Endpoint>): RestEndpointReader<Endpoint> {
+      logger.debug { "Building REST endpoint reader for endpoint $endpoint." }
+      require(endpoint.isData) { "REST endpoint ${endpoint.qualifiedName!!} must be a data class or data object." }
+      if (endpoint.objectInstance != null) {
+        logger.debug { "Using object instance REST endpoint reader for $endpoint." }
+        return DataObjectRestEndpointReader(endpoint)
+      }
+      logger.debug { "Using data class REST endpoint reader for $endpoint." }
+      return DataClassRestEndpointReader(endpoint)
+    }
+  }
+}

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointTemplate.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestEndpointTemplate.kt
@@ -16,7 +16,7 @@ private val logger: KLogger = KotlinLogging.logger {}
 
 /**
  * A REST endpoint template instance represents a specific subclass of [RestEndpoint].
- * In fact, it can be created from a [RestEndpoint] class reference using [RestEndpointTemplate.parse].
+ * In fact, it can be created from a [RestEndpoint] class reference using [RestEndpointTemplate.from].
  */
 internal data class RestEndpointTemplate(
   val method: HttpMethod,
@@ -29,7 +29,7 @@ internal data class RestEndpointTemplate(
     "RestEndpointTemplate(${PrettyRestEndpointWriter.write(this)})"
 
   internal companion object {
-    fun parse(endpoint: KClass<out RestEndpoint<*, *>>): RestEndpointTemplate {
+    fun from(endpoint: KClass<out RestEndpoint<*, *>>): RestEndpointTemplate {
       logger.debug { "Building REST endpoint template for endpoint $endpoint." }
       require(endpoint.isData) { "REST endpoint ${endpoint.qualifiedName!!} must be a data class or data object." }
       validateParams(endpoint)

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestHandler.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestHandler.kt
@@ -1,7 +1,12 @@
 package kairo.restFeature
 
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.server.routing.RoutingCall
 import kairo.reflect.typeParam
 import kotlin.reflect.KClass
+
+private val logger: KLogger = KotlinLogging.logger {}
 
 /**
  * A [RestHandler] implementation is the entrypoint for a specific [RestEndpoint].
@@ -10,9 +15,11 @@ import kotlin.reflect.KClass
 public abstract class RestHandler<Endpoint : RestEndpoint<*, *>> {
   private val endpoint: KClass<Endpoint> = typeParam(RestHandler::class, 0, this::class)
 
-  internal val template: RestEndpointTemplate = RestEndpointTemplate.parse(endpoint)
+  internal val template: RestEndpointTemplate = RestEndpointTemplate.from(endpoint)
+  private val reader: RestEndpointReader<Endpoint> = RestEndpointReader.from(endpoint)
 
-  internal fun handle() {
-    // TODO.
+  internal suspend fun handle(call: RoutingCall) {
+    val endpoint = reader.endpoint(call)
+    logger.info { "Got endpoint: $endpoint." } // TODO: Switch this to debug.
   }
 }

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/createModule.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/createModule.kt
@@ -27,7 +27,7 @@ internal fun createModule(handlers: Set<RestHandler<*>>): Application.() -> Unit
       val template = handler.template
       logger.info { "Registering REST handler: $template." }
       routing {
-        route(template).handle { handler.handle() }
+        route(template).handle { handler.handle(call) }
       }
     }
   }

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/ktorMapper.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/ktorMapper.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper
 import kairo.serialization.ObjectMapperFactory
 import kairo.serialization.ObjectMapperFormat
 
-internal val ktorObjectMapper: JsonMapper =
+internal val ktorMapper: JsonMapper =
   ObjectMapperFactory.builder(ObjectMapperFormat.Json).apply {
     prettyPrint = true
   }.build()

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/ktorObjectMapper.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/ktorObjectMapper.kt
@@ -1,0 +1,10 @@
+package kairo.restFeature
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import kairo.serialization.ObjectMapperFactory
+import kairo.serialization.ObjectMapperFormat
+
+internal val ktorObjectMapper: JsonMapper =
+  ObjectMapperFactory.builder(ObjectMapperFormat.Json).apply {
+    prettyPrint = true
+  }.build()

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenAcceptRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenAcceptRestEndpointTemplateTest.kt
@@ -17,7 +17,7 @@ internal class BrokenAcceptRestEndpointTemplateTest {
   @Test
   fun acceptPresentOnGet(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenAcceptLibraryBookApi.AcceptNotPresentOnGet::class)
+      RestEndpointTemplate.from(BrokenAcceptLibraryBookApi.AcceptNotPresentOnGet::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenAcceptLibraryBookApi.AcceptNotPresentOnGet" +
         " requires @Accept.",
@@ -27,7 +27,7 @@ internal class BrokenAcceptRestEndpointTemplateTest {
   @Test
   fun acceptNotPresentOnPost(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenAcceptLibraryBookApi.AcceptNotPresentOnPost::class)
+      RestEndpointTemplate.from(BrokenAcceptLibraryBookApi.AcceptNotPresentOnPost::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenAcceptLibraryBookApi.AcceptNotPresentOnPost" +
         " requires @Accept.",
@@ -39,7 +39,7 @@ internal class BrokenAcceptRestEndpointTemplateTest {
    */
   @Test
   fun emptyAccept(): Unit = runTest {
-    RestEndpointTemplate.parse(BrokenAcceptLibraryBookApi.EmptyAccept::class)
+    RestEndpointTemplate.from(BrokenAcceptLibraryBookApi.EmptyAccept::class)
       .shouldBe(
         RestEndpointTemplate(
           method = HttpMethod.Get,
@@ -58,7 +58,7 @@ internal class BrokenAcceptRestEndpointTemplateTest {
   @Test
   fun malformedAccept(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenAcceptLibraryBookApi.MalformedAccept::class)
+      RestEndpointTemplate.from(BrokenAcceptLibraryBookApi.MalformedAccept::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenAcceptLibraryBookApi.MalformedAccept" +
         " accept is invalid. Bad Content-Type format: application.",

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenContentTypeRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenContentTypeRestEndpointTemplateTest.kt
@@ -17,7 +17,7 @@ internal class BrokenContentTypeRestEndpointTemplateTest {
   @Test
   fun contentTypePresentOnGet(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenContentTypeLibraryBookApi.ContentTypePresentOnGet::class)
+      RestEndpointTemplate.from(BrokenContentTypeLibraryBookApi.ContentTypePresentOnGet::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenContentTypeLibraryBookApi.ContentTypePresentOnGet" +
         " may not have @ContentType since it does not have a body.",
@@ -27,7 +27,7 @@ internal class BrokenContentTypeRestEndpointTemplateTest {
   @Test
   fun contentTypeNotPresentOnPost(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenContentTypeLibraryBookApi.ContentTypeNotPresentOnPost::class)
+      RestEndpointTemplate.from(BrokenContentTypeLibraryBookApi.ContentTypeNotPresentOnPost::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenContentTypeLibraryBookApi.ContentTypeNotPresentOnPost" +
         " requires @ContentType since it has a body.",
@@ -39,7 +39,7 @@ internal class BrokenContentTypeRestEndpointTemplateTest {
    */
   @Test
   fun emptyContentType(): Unit = runTest {
-    RestEndpointTemplate.parse(BrokenContentTypeLibraryBookApi.EmptyContentType::class)
+    RestEndpointTemplate.from(BrokenContentTypeLibraryBookApi.EmptyContentType::class)
       .shouldBe(
         RestEndpointTemplate(
           method = HttpMethod.Post,
@@ -57,7 +57,7 @@ internal class BrokenContentTypeRestEndpointTemplateTest {
   @Test
   fun malformedContentType(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenContentTypeLibraryBookApi.MalformedContentType::class)
+      RestEndpointTemplate.from(BrokenContentTypeLibraryBookApi.MalformedContentType::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenContentTypeLibraryBookApi.MalformedContentType" +
         " content type is invalid. Bad Content-Type format: application.",

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenMethodRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenMethodRestEndpointTemplateTest.kt
@@ -14,7 +14,7 @@ internal class BrokenMethodRestEndpointTemplateTest {
   @Test
   fun missingMethod(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenMethodLibraryBookApi.MissingMethod::class)
+      RestEndpointTemplate.from(BrokenMethodLibraryBookApi.MissingMethod::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenMethodLibraryBookApi.MissingMethod" +
         " is missing @Method.",
@@ -24,7 +24,7 @@ internal class BrokenMethodRestEndpointTemplateTest {
   @Test
   fun emptyMethod(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenMethodLibraryBookApi.EmptyMethod::class)
+      RestEndpointTemplate.from(BrokenMethodLibraryBookApi.EmptyMethod::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenMethodLibraryBookApi.EmptyMethod" +
         " has invalid method: .",
@@ -34,7 +34,7 @@ internal class BrokenMethodRestEndpointTemplateTest {
   @Test
   fun sync(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenMethodLibraryBookApi.UnsupportedMethod::class)
+      RestEndpointTemplate.from(BrokenMethodLibraryBookApi.UnsupportedMethod::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenMethodLibraryBookApi.UnsupportedMethod" +
         " has invalid method: SYNC.",

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenParamRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenParamRestEndpointTemplateTest.kt
@@ -74,7 +74,7 @@ internal class BrokenParamRestEndpointTemplateTest {
   @Test
   fun nullablePathParam(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenParamLibraryBookApi.NullablePathParam::class)
+      RestEndpointTemplate.from(BrokenParamLibraryBookApi.NullablePathParam::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenParamLibraryBookApi.NullablePathParam" +
         " path is invalid. Path param must not be nullable: libraryBookId.",
@@ -84,7 +84,7 @@ internal class BrokenParamRestEndpointTemplateTest {
   @Test
   fun optionalPathParam(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenParamLibraryBookApi.OptionalPathParam::class)
+      RestEndpointTemplate.from(BrokenParamLibraryBookApi.OptionalPathParam::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenParamLibraryBookApi.OptionalPathParam" +
         " path is invalid. Path param must not be optional: libraryBookId.",
@@ -94,7 +94,7 @@ internal class BrokenParamRestEndpointTemplateTest {
   @Test
   fun optionalQueryParam(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenParamLibraryBookApi.OptionalQueryParam::class)
+      RestEndpointTemplate.from(BrokenParamLibraryBookApi.OptionalQueryParam::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenParamLibraryBookApi.OptionalQueryParam" +
         " query is invalid. Query param must not be optional: title.",

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenParamRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenParamRestEndpointTemplateTest.kt
@@ -14,7 +14,7 @@ internal class BrokenParamRestEndpointTemplateTest {
   @Test
   fun nonParamConstructorParameter(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenParamLibraryBookApi.NonParamConstructorParameter::class)
+      RestEndpointTemplate.from(BrokenParamLibraryBookApi.NonParamConstructorParameter::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenParamLibraryBookApi.NonParamConstructorParameter" +
         " param must be path or query: shouldNotBeHere.",
@@ -24,7 +24,7 @@ internal class BrokenParamRestEndpointTemplateTest {
   @Test
   fun bodyAsPathParam(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenParamLibraryBookApi.BodyAsPathParam::class)
+      RestEndpointTemplate.from(BrokenParamLibraryBookApi.BodyAsPathParam::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenParamLibraryBookApi.BodyAsPathParam" +
         " body cannot be param.",
@@ -34,7 +34,7 @@ internal class BrokenParamRestEndpointTemplateTest {
   @Test
   fun bodyAsQueryParam(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenParamLibraryBookApi.BodyAsQueryParam::class)
+      RestEndpointTemplate.from(BrokenParamLibraryBookApi.BodyAsQueryParam::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenParamLibraryBookApi.BodyAsQueryParam" +
         " body cannot be param.",
@@ -44,7 +44,7 @@ internal class BrokenParamRestEndpointTemplateTest {
   @Test
   fun pathParamMarkedAsQueryParam(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenParamLibraryBookApi.PathParamMarkedAsQueryParam::class)
+      RestEndpointTemplate.from(BrokenParamLibraryBookApi.PathParamMarkedAsQueryParam::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenParamLibraryBookApi.PathParamMarkedAsQueryParam" +
         " path is invalid. Path param in path but not in constructor: libraryBookId.",
@@ -54,7 +54,7 @@ internal class BrokenParamRestEndpointTemplateTest {
   @Test
   fun queryParamMarkedAsPathParam(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenParamLibraryBookApi.QueryParamMarkedAsPathParam::class)
+      RestEndpointTemplate.from(BrokenParamLibraryBookApi.QueryParamMarkedAsPathParam::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenParamLibraryBookApi.QueryParamMarkedAsPathParam" +
         " path is invalid. Path param in constructor but not in path: isbn.",
@@ -64,7 +64,7 @@ internal class BrokenParamRestEndpointTemplateTest {
   @Test
   fun paramIsPathAndQuery(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenParamLibraryBookApi.ParamIsPathAndQuery::class)
+      RestEndpointTemplate.from(BrokenParamLibraryBookApi.ParamIsPathAndQuery::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenParamLibraryBookApi.ParamIsPathAndQuery" +
         " param cannot be both path and query: libraryBookId.",

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenPathRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenPathRestEndpointTemplateTest.kt
@@ -14,7 +14,7 @@ internal class BrokenPathRestEndpointTemplateTest {
   @Test
   fun missingMethod(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.MissingPath::class)
+      RestEndpointTemplate.from(BrokenPathLibraryBookApi.MissingPath::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.MissingPath" +
         " is missing @Path.",
@@ -24,7 +24,7 @@ internal class BrokenPathRestEndpointTemplateTest {
   @Test
   fun emptyMethod(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.EmptyPath::class)
+      RestEndpointTemplate.from(BrokenPathLibraryBookApi.EmptyPath::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.EmptyPath" +
         " path must start with a slash: .",
@@ -34,7 +34,7 @@ internal class BrokenPathRestEndpointTemplateTest {
   @Test
   fun pathMissingLeadingSlash(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.PathMissingLeadingSlash::class)
+      RestEndpointTemplate.from(BrokenPathLibraryBookApi.PathMissingLeadingSlash::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.PathMissingLeadingSlash" +
         " path must start with a slash: library/library-books.",
@@ -44,7 +44,7 @@ internal class BrokenPathRestEndpointTemplateTest {
   @Test
   fun malformedConstantPathComponent(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.MalformedConstantPathComponent::class)
+      RestEndpointTemplate.from(BrokenPathLibraryBookApi.MalformedConstantPathComponent::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.MalformedConstantPathComponent" +
         " path is invalid. Path constants must be kebab case: libraryBooks.",
@@ -54,7 +54,7 @@ internal class BrokenPathRestEndpointTemplateTest {
   @Test
   fun malformedPathConstantComponent(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.MalformedConstantPathComponent::class)
+      RestEndpointTemplate.from(BrokenPathLibraryBookApi.MalformedConstantPathComponent::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.MalformedConstantPathComponent" +
         " path is invalid. Path constants must be kebab case: libraryBooks.",
@@ -64,7 +64,7 @@ internal class BrokenPathRestEndpointTemplateTest {
   @Test
   fun malformedParamPathComponent(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.MalformedParamPathComponent::class)
+      RestEndpointTemplate.from(BrokenPathLibraryBookApi.MalformedParamPathComponent::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.MalformedParamPathComponent" +
         " path is invalid. Path params must be camel case: library-book-id.",
@@ -74,7 +74,7 @@ internal class BrokenPathRestEndpointTemplateTest {
   @Test
   fun nullablePathParam(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.NullablePathParam::class)
+      RestEndpointTemplate.from(BrokenPathLibraryBookApi.NullablePathParam::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.NullablePathParam" +
         " path is invalid. Path param must not be nullable: libraryBookId.",
@@ -84,7 +84,7 @@ internal class BrokenPathRestEndpointTemplateTest {
   @Test
   fun optionalPathParam(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.OptionalPathParam::class)
+      RestEndpointTemplate.from(BrokenPathLibraryBookApi.OptionalPathParam::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.OptionalPathParam" +
         " path is invalid. Path param must not be optional: libraryBookId.",
@@ -94,7 +94,7 @@ internal class BrokenPathRestEndpointTemplateTest {
   @Test
   fun duplicatePathParamInPath(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.DuplicatePathParamInPath::class)
+      RestEndpointTemplate.from(BrokenPathLibraryBookApi.DuplicatePathParamInPath::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.DuplicatePathParamInPath" +
         " path is invalid. Duplicate path param in path: libraryBookId.",
@@ -104,7 +104,7 @@ internal class BrokenPathRestEndpointTemplateTest {
   @Test
   fun pathParamInPathButNotInConstructor(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.PathParamInPathButNotInConstructor::class)
+      RestEndpointTemplate.from(BrokenPathLibraryBookApi.PathParamInPathButNotInConstructor::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.PathParamInPathButNotInConstructor" +
         " path is invalid. Path param in path but not in constructor: libraryBookId.",
@@ -114,7 +114,7 @@ internal class BrokenPathRestEndpointTemplateTest {
   @Test
   fun pathParamInConstructorButNotInPath(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenPathLibraryBookApi.PathParamInConstructorButNotInPath::class)
+      RestEndpointTemplate.from(BrokenPathLibraryBookApi.PathParamInConstructorButNotInPath::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenPathLibraryBookApi.PathParamInConstructorButNotInPath" +
         " path is invalid. Path param in constructor but not in path: libraryBookId.",

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenRestEndpointTemplateTest.kt
@@ -13,7 +13,7 @@ internal class BrokenRestEndpointTemplateTest {
   @Test
   fun notDataClass(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenLibraryBookApi.NotDataClass::class)
+      RestEndpointTemplate.from(BrokenLibraryBookApi.NotDataClass::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenLibraryBookApi.NotDataClass" +
         " must be a data class or data object.",
@@ -23,7 +23,7 @@ internal class BrokenRestEndpointTemplateTest {
   @Test
   fun notDataObject(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenLibraryBookApi.NotDataObject::class)
+      RestEndpointTemplate.from(BrokenLibraryBookApi.NotDataObject::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenLibraryBookApi.NotDataObject" +
         " must be a data class or data object.",

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenTypeRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenTypeRestEndpointTemplateTest.kt
@@ -13,7 +13,7 @@ internal class BrokenTypeRestEndpointTemplateTest {
   @Test
   fun getWithBodyNotProvided(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenTypeLibraryBookApi.GetWithBodyNotProvided::class)
+      RestEndpointTemplate.from(BrokenTypeLibraryBookApi.GetWithBodyNotProvided::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenTypeLibraryBookApi.GetWithBodyNotProvided" +
         " has method GET but specifies a body.",
@@ -23,7 +23,7 @@ internal class BrokenTypeRestEndpointTemplateTest {
   @Test
   fun getWithBodyProvided(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenTypeLibraryBookApi.GetWithBodyProvided::class)
+      RestEndpointTemplate.from(BrokenTypeLibraryBookApi.GetWithBodyProvided::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenTypeLibraryBookApi.GetWithBodyProvided" +
         " has method GET but specifies a body.",
@@ -33,7 +33,7 @@ internal class BrokenTypeRestEndpointTemplateTest {
   @Test
   fun postWithoutBodyNotProvided(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenTypeLibraryBookApi.PostWithoutBodyProvided::class)
+      RestEndpointTemplate.from(BrokenTypeLibraryBookApi.PostWithoutBodyProvided::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenTypeLibraryBookApi.PostWithoutBodyProvided" +
         " has method POST but specifies a body.",
@@ -43,7 +43,7 @@ internal class BrokenTypeRestEndpointTemplateTest {
   @Test
   fun postWithoutBodyProvided(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
-      RestEndpointTemplate.parse(BrokenTypeLibraryBookApi.PostWithoutBodyNotProvided::class)
+      RestEndpointTemplate.from(BrokenTypeLibraryBookApi.PostWithoutBodyNotProvided::class)
     }.shouldHaveMessage(
       "REST endpoint kairo.restFeature.BrokenTypeLibraryBookApi.PostWithoutBodyNotProvided" +
         " has method POST but specifies a body.",

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/KtorPathTemplateRestEndpointWriterTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/KtorPathTemplateRestEndpointWriterTest.kt
@@ -7,49 +7,49 @@ import org.junit.jupiter.api.Test
 internal class KtorPathTemplateRestEndpointWriterTest {
   @Test
   fun get(): Unit = runTest {
-    val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.Get::class)
+    val template = RestEndpointTemplate.from(TypicalLibraryBookApi.Get::class)
     KtorPathTemplateRestEndpointWriter.write(template)
       .shouldBe("library/library-books/{libraryBookId}")
   }
 
   @Test
   fun listAll(): Unit = runTest {
-    val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.ListAll::class)
+    val template = RestEndpointTemplate.from(TypicalLibraryBookApi.ListAll::class)
     KtorPathTemplateRestEndpointWriter.write(template)
       .shouldBe("library/library-books")
   }
 
   @Test
   fun searchByIsbn(): Unit = runTest {
-    val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.SearchByIsbn::class)
+    val template = RestEndpointTemplate.from(TypicalLibraryBookApi.SearchByIsbn::class)
     KtorPathTemplateRestEndpointWriter.write(template)
       .shouldBe("library/library-books")
   }
 
   @Test
   fun searchByTitle(): Unit = runTest {
-    val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.SearchByText::class)
+    val template = RestEndpointTemplate.from(TypicalLibraryBookApi.SearchByText::class)
     KtorPathTemplateRestEndpointWriter.write(template)
       .shouldBe("library/library-books")
   }
 
   @Test
   fun create(): Unit = runTest {
-    val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.Create::class)
+    val template = RestEndpointTemplate.from(TypicalLibraryBookApi.Create::class)
     KtorPathTemplateRestEndpointWriter.write(template)
       .shouldBe("library/library-books")
   }
 
   @Test
   fun update(): Unit = runTest {
-    val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.Update::class)
+    val template = RestEndpointTemplate.from(TypicalLibraryBookApi.Update::class)
     KtorPathTemplateRestEndpointWriter.write(template)
       .shouldBe("library/library-books/{libraryBookId}")
   }
 
   @Test
   fun delete(): Unit = runTest {
-    val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.Delete::class)
+    val template = RestEndpointTemplate.from(TypicalLibraryBookApi.Delete::class)
     KtorPathTemplateRestEndpointWriter.write(template)
       .shouldBe("library/library-books/{libraryBookId}")
   }

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/LibraryBookRep.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/LibraryBookRep.kt
@@ -1,21 +1,22 @@
 package kairo.restFeature
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import java.util.Optional
 import kairo.id.KairoId
 
 internal data class LibraryBookRep(
   val id: KairoId,
   val title: String,
-  val author: String,
+  val author: String?,
 ) {
   internal data class Creator(
     val title: String,
-    val author: String,
+    val author: String?,
   )
 
   @JsonInclude(value = JsonInclude.Include.NON_NULL)
   internal data class Update(
     val title: String? = null,
-    val author: String? = null,
+    val author: Optional<String>? = null,
   )
 }

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/PrettyRestEndpointWriterTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/PrettyRestEndpointWriterTest.kt
@@ -7,49 +7,49 @@ import org.junit.jupiter.api.Test
 internal class PrettyRestEndpointWriterTest {
   @Test
   fun get(): Unit = runTest {
-    val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.Get::class)
+    val template = RestEndpointTemplate.from(TypicalLibraryBookApi.Get::class)
     PrettyRestEndpointWriter.write(template)
       .shouldBe("[ -> application/json] GET library/library-books/:libraryBookId")
   }
 
   @Test
   fun listAll(): Unit = runTest {
-    val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.ListAll::class)
+    val template = RestEndpointTemplate.from(TypicalLibraryBookApi.ListAll::class)
     PrettyRestEndpointWriter.write(template)
       .shouldBe("[ -> application/json] GET library/library-books")
   }
 
   @Test
   fun searchByIsbn(): Unit = runTest {
-    val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.SearchByIsbn::class)
+    val template = RestEndpointTemplate.from(TypicalLibraryBookApi.SearchByIsbn::class)
     PrettyRestEndpointWriter.write(template)
       .shouldBe("[ -> application/json] GET library/library-books (isbn)")
   }
 
   @Test
   fun searchByTitle(): Unit = runTest {
-    val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.SearchByText::class)
+    val template = RestEndpointTemplate.from(TypicalLibraryBookApi.SearchByText::class)
     PrettyRestEndpointWriter.write(template)
       .shouldBe("[ -> application/json] GET library/library-books (title?, author?)")
   }
 
   @Test
   fun create(): Unit = runTest {
-    val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.Create::class)
+    val template = RestEndpointTemplate.from(TypicalLibraryBookApi.Create::class)
     PrettyRestEndpointWriter.write(template)
       .shouldBe("[application/json -> application/json] POST library/library-books")
   }
 
   @Test
   fun update(): Unit = runTest {
-    val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.Update::class)
+    val template = RestEndpointTemplate.from(TypicalLibraryBookApi.Update::class)
     PrettyRestEndpointWriter.write(template)
       .shouldBe("[application/json -> application/json] PATCH library/library-books/:libraryBookId")
   }
 
   @Test
   fun delete(): Unit = runTest {
-    val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.Delete::class)
+    val template = RestEndpointTemplate.from(TypicalLibraryBookApi.Delete::class)
     PrettyRestEndpointWriter.write(template)
       .shouldBe("[ -> application/json] DELETE library/library-books/:libraryBookId")
   }

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/RestEndpointReaderTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/RestEndpointReaderTest.kt
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test
  */
 internal class RestEndpointReaderTest {
   @Test
-  fun `get, invalid path param`() = runTest {
+  fun `get, invalid path param`(): Unit = runTest {
     val reader = RestEndpointReader.from(TypicalLibraryBookApi.Get::class)
     val call = mockk<RoutingCall> {
       every { parameters } returns Parameters.build {
@@ -38,7 +38,7 @@ internal class RestEndpointReaderTest {
   }
 
   @Test
-  fun `get, happy path`() = runTest {
+  fun `get, happy path`(): Unit = runTest {
     val reader = RestEndpointReader.from(TypicalLibraryBookApi.Get::class)
     val call = mockk<RoutingCall> {
       every { parameters } returns Parameters.build {
@@ -54,7 +54,7 @@ internal class RestEndpointReaderTest {
   }
 
   @Test
-  fun `listAll, happy path`() = runTest {
+  fun `listAll, happy path`(): Unit = runTest {
     val reader = RestEndpointReader.from(TypicalLibraryBookApi.ListAll::class)
     val call = mockk<RoutingCall>()
     reader.endpoint(call)
@@ -64,7 +64,7 @@ internal class RestEndpointReaderTest {
   }
 
   @Test
-  fun `searchByIsbn, missing isbn`() = runTest {
+  fun `searchByIsbn, missing isbn`(): Unit = runTest {
     val reader = RestEndpointReader.from(TypicalLibraryBookApi.SearchByIsbn::class)
     val call = mockk<RoutingCall> {
       every { parameters } returns Parameters.Empty
@@ -75,7 +75,7 @@ internal class RestEndpointReaderTest {
   }
 
   @Test
-  fun `searchByIsbn, happy path`() = runTest {
+  fun `searchByIsbn, happy path`(): Unit = runTest {
     val reader = RestEndpointReader.from(TypicalLibraryBookApi.SearchByIsbn::class)
     val call = mockk<RoutingCall> {
       every { parameters } returns Parameters.build {
@@ -91,7 +91,7 @@ internal class RestEndpointReaderTest {
   }
 
   @Test
-  fun `searchByText, happy path (neither provided)`() = runTest {
+  fun `searchByText, happy path (neither provided)`(): Unit = runTest {
     val reader = RestEndpointReader.from(TypicalLibraryBookApi.SearchByText::class)
     val call = mockk<RoutingCall> {
       every { parameters } returns Parameters.Empty
@@ -106,7 +106,7 @@ internal class RestEndpointReaderTest {
   }
 
   @Test
-  fun `searchByText, happy path (both provided)`() = runTest {
+  fun `searchByText, happy path (both provided)`(): Unit = runTest {
     val reader = RestEndpointReader.from(TypicalLibraryBookApi.SearchByText::class)
     val call = mockk<RoutingCall> {
       every { parameters } returns Parameters.build {
@@ -124,7 +124,7 @@ internal class RestEndpointReaderTest {
   }
 
   @Test
-  fun `create, missing required property`() = runTest {
+  fun `create, missing required property`(): Unit = runTest {
     val reader = RestEndpointReader.from(TypicalLibraryBookApi.Create::class)
     val call = mockk<RoutingCall> {
       coEvery { receiveStream() } returns ktorMapper.writeValueAsBytes(
@@ -137,7 +137,7 @@ internal class RestEndpointReaderTest {
   }
 
   @Test
-  fun `create, has additional property`() = runTest {
+  fun `create, has additional property`(): Unit = runTest {
     val reader = RestEndpointReader.from(TypicalLibraryBookApi.Create::class)
     val call = mockk<RoutingCall> {
       coEvery { receiveStream() } returns ktorMapper.writeValueAsBytes(
@@ -150,7 +150,7 @@ internal class RestEndpointReaderTest {
   }
 
   @Test
-  fun `create, property is wrong type`() = runTest {
+  fun `create, property is wrong type`(): Unit = runTest {
     val reader = RestEndpointReader.from(TypicalLibraryBookApi.Create::class)
     val call = mockk<RoutingCall> {
       coEvery { receiveStream() } returns ktorMapper.writeValueAsBytes(
@@ -163,7 +163,7 @@ internal class RestEndpointReaderTest {
   }
 
   @Test
-  fun `create, happy path`() = runTest {
+  fun `create, happy path`(): Unit = runTest {
     val reader = RestEndpointReader.from(TypicalLibraryBookApi.Create::class)
     val call = mockk<RoutingCall> {
       coEvery { receiveStream() } returns ktorMapper.writeValueAsBytes(
@@ -182,7 +182,7 @@ internal class RestEndpointReaderTest {
   }
 
   @Test
-  fun `update, invalid path param`() = runTest {
+  fun `update, invalid path param`(): Unit = runTest {
     val reader = RestEndpointReader.from(TypicalLibraryBookApi.Update::class)
     val call = mockk<RoutingCall> {
       every { parameters } returns Parameters.build {
@@ -198,7 +198,7 @@ internal class RestEndpointReaderTest {
   }
 
   @Test
-  fun `update, has additional property`() = runTest {
+  fun `update, has additional property`(): Unit = runTest {
     val reader = RestEndpointReader.from(TypicalLibraryBookApi.Update::class)
     val call = mockk<RoutingCall> {
       every { parameters } returns Parameters.build {
@@ -214,7 +214,7 @@ internal class RestEndpointReaderTest {
   }
 
   @Test
-  fun `property is wrong type`() = runTest {
+  fun `property is wrong type`(): Unit = runTest {
     val reader = RestEndpointReader.from(TypicalLibraryBookApi.Update::class)
     val call = mockk<RoutingCall> {
       every { parameters } returns Parameters.build {
@@ -230,7 +230,7 @@ internal class RestEndpointReaderTest {
   }
 
   @Test
-  fun `update, happy path (neither provided)`() = runTest {
+  fun `update, happy path (neither provided)`(): Unit = runTest {
     val reader = RestEndpointReader.from(TypicalLibraryBookApi.Update::class)
     val call = mockk<RoutingCall> {
       every { parameters } returns Parameters.build {
@@ -253,14 +253,14 @@ internal class RestEndpointReaderTest {
   }
 
   @Test
-  fun `update, happy path (author null)`() = runTest {
+  fun `update, happy path (author null)`(): Unit = runTest {
     val reader = RestEndpointReader.from(TypicalLibraryBookApi.Update::class)
     val call = mockk<RoutingCall> {
       every { parameters } returns Parameters.build {
         append("libraryBookId", "library_book_2eDS1sMt")
       }
       coEvery { receiveStream() } returns ktorMapper.writeValueAsBytes(
-        mapOf("author" to null)
+        mapOf("author" to null),
       ).inputStream()
     }
     reader.endpoint(call)
@@ -276,7 +276,7 @@ internal class RestEndpointReaderTest {
   }
 
   @Test
-  fun `update, happy path (both provided)`() = runTest {
+  fun `update, happy path (both provided)`(): Unit = runTest {
     val reader = RestEndpointReader.from(TypicalLibraryBookApi.Update::class)
     val call = mockk<RoutingCall> {
       every { parameters } returns Parameters.build {
@@ -299,7 +299,7 @@ internal class RestEndpointReaderTest {
   }
 
   @Test
-  fun `delete, invalid path param`() = runTest {
+  fun `delete, invalid path param`(): Unit = runTest {
     val reader = RestEndpointReader.from(TypicalLibraryBookApi.Delete::class)
     val call = mockk<RoutingCall> {
       every { parameters } returns Parameters.build {
@@ -312,7 +312,7 @@ internal class RestEndpointReaderTest {
   }
 
   @Test
-  fun `delete, happy path`() = runTest {
+  fun `delete, happy path`(): Unit = runTest {
     val reader = RestEndpointReader.from(TypicalLibraryBookApi.Delete::class)
     val call = mockk<RoutingCall> {
       every { parameters } returns Parameters.build {

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/RestEndpointReaderTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/RestEndpointReaderTest.kt
@@ -1,0 +1,329 @@
+package kairo.restFeature
+
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.ktor.http.Parameters
+import io.ktor.server.request.receiveStream
+import io.ktor.server.routing.RoutingCall
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import java.lang.reflect.InvocationTargetException
+import java.util.Optional
+import kairo.id.KairoId
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * This test verifies that [RestEndpointReader] can properly derive [RestEndpoint] instances from [RoutingCall]s.
+ *
+ * Note that for bodies, this test serializes maps and lists instead of data classes
+ * in order to avoid symmetrical unexpected serialization issues
+ * and test non-happy paths.
+ */
+internal class RestEndpointReaderTest {
+  @Test
+  fun `get, invalid path param`() = runTest {
+    val reader = RestEndpointReader.from(TypicalLibraryBookApi.Get::class)
+    val call = mockk<RoutingCall> {
+      every { parameters } returns Parameters.build {
+        append("libraryBookId", "2eDS1sMt")
+      }
+    }
+    shouldThrow<IllegalArgumentException> {
+      reader.endpoint(call)
+    }
+  }
+
+  @Test
+  fun `get, happy path`() = runTest {
+    val reader = RestEndpointReader.from(TypicalLibraryBookApi.Get::class)
+    val call = mockk<RoutingCall> {
+      every { parameters } returns Parameters.build {
+        append("libraryBookId", "library_book_2eDS1sMt")
+      }
+    }
+    reader.endpoint(call)
+      .shouldBe(
+        TypicalLibraryBookApi.Get(
+          libraryBookId = KairoId("library_book", "2eDS1sMt"),
+        ),
+      )
+  }
+
+  @Test
+  fun `listAll, happy path`() = runTest {
+    val reader = RestEndpointReader.from(TypicalLibraryBookApi.ListAll::class)
+    val call = mockk<RoutingCall>()
+    reader.endpoint(call)
+      .shouldBe(
+        TypicalLibraryBookApi.ListAll,
+      )
+  }
+
+  @Test
+  fun `searchByIsbn, missing isbn`() = runTest {
+    val reader = RestEndpointReader.from(TypicalLibraryBookApi.SearchByIsbn::class)
+    val call = mockk<RoutingCall> {
+      every { parameters } returns Parameters.Empty
+    }
+    shouldThrow<InvocationTargetException> {
+      reader.endpoint(call)
+    }
+  }
+
+  @Test
+  fun `searchByIsbn, happy path`() = runTest {
+    val reader = RestEndpointReader.from(TypicalLibraryBookApi.SearchByIsbn::class)
+    val call = mockk<RoutingCall> {
+      every { parameters } returns Parameters.build {
+        append("isbn", "978-0756405892")
+      }
+    }
+    reader.endpoint(call)
+      .shouldBe(
+        TypicalLibraryBookApi.SearchByIsbn(
+          isbn = "978-0756405892",
+        ),
+      )
+  }
+
+  @Test
+  fun `searchByText, happy path (neither provided)`() = runTest {
+    val reader = RestEndpointReader.from(TypicalLibraryBookApi.SearchByText::class)
+    val call = mockk<RoutingCall> {
+      every { parameters } returns Parameters.Empty
+    }
+    reader.endpoint(call)
+      .shouldBe(
+        TypicalLibraryBookApi.SearchByText(
+          title = null,
+          author = null,
+        ),
+      )
+  }
+
+  @Test
+  fun `searchByText, happy path (both provided)`() = runTest {
+    val reader = RestEndpointReader.from(TypicalLibraryBookApi.SearchByText::class)
+    val call = mockk<RoutingCall> {
+      every { parameters } returns Parameters.build {
+        append("title", "The Name of the Wind")
+        append("author", "Patrick Rothfuss")
+      }
+    }
+    reader.endpoint(call)
+      .shouldBe(
+        TypicalLibraryBookApi.SearchByText(
+          title = "The Name of the Wind",
+          author = "Patrick Rothfuss",
+        ),
+      )
+  }
+
+  @Test
+  fun `create, missing required property`() = runTest {
+    val reader = RestEndpointReader.from(TypicalLibraryBookApi.Create::class)
+    val call = mockk<RoutingCall> {
+      coEvery { receiveStream() } returns ktorMapper.writeValueAsBytes(
+        mapOf("author" to "Patrick Rothfuss"),
+      ).inputStream()
+    }
+    shouldThrow<MismatchedInputException> {
+      reader.endpoint(call)
+    }
+  }
+
+  @Test
+  fun `create, has additional property`() = runTest {
+    val reader = RestEndpointReader.from(TypicalLibraryBookApi.Create::class)
+    val call = mockk<RoutingCall> {
+      coEvery { receiveStream() } returns ktorMapper.writeValueAsBytes(
+        mapOf("title" to "The Name of the Wind", "author" to "Patrick Rothfuss", "isbn" to "978-0756405892"),
+      ).inputStream()
+    }
+    shouldThrow<UnrecognizedPropertyException> {
+      reader.endpoint(call)
+    }
+  }
+
+  @Test
+  fun `create, property is wrong type`() = runTest {
+    val reader = RestEndpointReader.from(TypicalLibraryBookApi.Create::class)
+    val call = mockk<RoutingCall> {
+      coEvery { receiveStream() } returns ktorMapper.writeValueAsBytes(
+        mapOf("title" to "The Name of the Wind", "author" to 7),
+      ).inputStream()
+    }
+    shouldThrow<MismatchedInputException> {
+      reader.endpoint(call)
+    }
+  }
+
+  @Test
+  fun `create, happy path`() = runTest {
+    val reader = RestEndpointReader.from(TypicalLibraryBookApi.Create::class)
+    val call = mockk<RoutingCall> {
+      coEvery { receiveStream() } returns ktorMapper.writeValueAsBytes(
+        mapOf("title" to "The Name of the Wind", "author" to "Patrick Rothfuss"),
+      ).inputStream()
+    }
+    reader.endpoint(call)
+      .shouldBe(
+        TypicalLibraryBookApi.Create(
+          body = LibraryBookRep.Creator(
+            title = "The Name of the Wind",
+            author = "Patrick Rothfuss",
+          ),
+        ),
+      )
+  }
+
+  @Test
+  fun `update, invalid path param`() = runTest {
+    val reader = RestEndpointReader.from(TypicalLibraryBookApi.Update::class)
+    val call = mockk<RoutingCall> {
+      every { parameters } returns Parameters.build {
+        append("libraryBookId", "2eDS1sMt")
+      }
+      coEvery { receiveStream() } returns ktorMapper.writeValueAsBytes(
+        mapOf("title" to "The Name of the Wind", "author" to "Patrick Rothfuss"),
+      ).inputStream()
+    }
+    shouldThrow<IllegalArgumentException> {
+      reader.endpoint(call)
+    }
+  }
+
+  @Test
+  fun `update, has additional property`() = runTest {
+    val reader = RestEndpointReader.from(TypicalLibraryBookApi.Update::class)
+    val call = mockk<RoutingCall> {
+      every { parameters } returns Parameters.build {
+        append("libraryBookId", "library_book_2eDS1sMt")
+      }
+      coEvery { receiveStream() } returns ktorMapper.writeValueAsBytes(
+        mapOf("isbn" to "978-0756405892"),
+      ).inputStream()
+    }
+    shouldThrow<UnrecognizedPropertyException> {
+      reader.endpoint(call)
+    }
+  }
+
+  @Test
+  fun `property is wrong type`() = runTest {
+    val reader = RestEndpointReader.from(TypicalLibraryBookApi.Update::class)
+    val call = mockk<RoutingCall> {
+      every { parameters } returns Parameters.build {
+        append("libraryBookId", "library_book_2eDS1sMt")
+      }
+      coEvery { receiveStream() } returns ktorMapper.writeValueAsBytes(
+        mapOf("author" to 7),
+      ).inputStream()
+    }
+    shouldThrow<MismatchedInputException> {
+      reader.endpoint(call)
+    }
+  }
+
+  @Test
+  fun `update, happy path (neither provided)`() = runTest {
+    val reader = RestEndpointReader.from(TypicalLibraryBookApi.Update::class)
+    val call = mockk<RoutingCall> {
+      every { parameters } returns Parameters.build {
+        append("libraryBookId", "library_book_2eDS1sMt")
+      }
+      coEvery { receiveStream() } returns ktorMapper.writeValueAsBytes(
+        emptyMap<String, Any>(),
+      ).inputStream()
+    }
+    reader.endpoint(call)
+      .shouldBe(
+        TypicalLibraryBookApi.Update(
+          libraryBookId = KairoId("library_book", "2eDS1sMt"),
+          body = LibraryBookRep.Update(
+            title = null,
+            author = null,
+          ),
+        ),
+      )
+  }
+
+  @Test
+  fun `update, happy path (author null)`() = runTest {
+    val reader = RestEndpointReader.from(TypicalLibraryBookApi.Update::class)
+    val call = mockk<RoutingCall> {
+      every { parameters } returns Parameters.build {
+        append("libraryBookId", "library_book_2eDS1sMt")
+      }
+      coEvery { receiveStream() } returns ktorMapper.writeValueAsBytes(
+        mapOf("author" to null)
+      ).inputStream()
+    }
+    reader.endpoint(call)
+      .shouldBe(
+        TypicalLibraryBookApi.Update(
+          libraryBookId = KairoId("library_book", "2eDS1sMt"),
+          body = LibraryBookRep.Update(
+            title = null,
+            author = Optional.empty(),
+          ),
+        ),
+      )
+  }
+
+  @Test
+  fun `update, happy path (both provided)`() = runTest {
+    val reader = RestEndpointReader.from(TypicalLibraryBookApi.Update::class)
+    val call = mockk<RoutingCall> {
+      every { parameters } returns Parameters.build {
+        append("libraryBookId", "library_book_2eDS1sMt")
+      }
+      coEvery { receiveStream() } returns ktorMapper.writeValueAsBytes(
+        mapOf("title" to "The Name of the Wind", "author" to "Patrick Rothfuss"),
+      ).inputStream()
+    }
+    reader.endpoint(call)
+      .shouldBe(
+        TypicalLibraryBookApi.Update(
+          libraryBookId = KairoId("library_book", "2eDS1sMt"),
+          body = LibraryBookRep.Update(
+            title = "The Name of the Wind",
+            author = Optional.of("Patrick Rothfuss"),
+          ),
+        ),
+      )
+  }
+
+  @Test
+  fun `delete, invalid path param`() = runTest {
+    val reader = RestEndpointReader.from(TypicalLibraryBookApi.Delete::class)
+    val call = mockk<RoutingCall> {
+      every { parameters } returns Parameters.build {
+        append("libraryBookId", "2eDS1sMt")
+      }
+    }
+    shouldThrow<IllegalArgumentException> {
+      reader.endpoint(call)
+    }
+  }
+
+  @Test
+  fun `delete, happy path`() = runTest {
+    val reader = RestEndpointReader.from(TypicalLibraryBookApi.Delete::class)
+    val call = mockk<RoutingCall> {
+      every { parameters } returns Parameters.build {
+        append("libraryBookId", "library_book_2eDS1sMt")
+      }
+    }
+    reader.endpoint(call)
+      .shouldBe(
+        TypicalLibraryBookApi.Delete(
+          libraryBookId = KairoId("library_book", "2eDS1sMt"),
+        ),
+      )
+  }
+}

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/RestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/RestEndpointTemplateTest.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test
 internal class RestEndpointTemplateTest {
   @Test
   fun `get, toString method`(): Unit = runTest {
-    RestEndpointTemplate.parse(TypicalLibraryBookApi.Get::class).toString()
+    RestEndpointTemplate.from(TypicalLibraryBookApi.Get::class).toString()
       .shouldBe(
         "RestEndpointTemplate([ -> application/json]" +
           " GET library/library-books/:libraryBookId)",
@@ -21,7 +21,7 @@ internal class RestEndpointTemplateTest {
 
   @Test
   fun `listAll, toString method`(): Unit = runTest {
-    RestEndpointTemplate.parse(TypicalLibraryBookApi.ListAll::class).toString()
+    RestEndpointTemplate.from(TypicalLibraryBookApi.ListAll::class).toString()
       .shouldBe(
         "RestEndpointTemplate([ -> application/json]" +
           " GET library/library-books)",
@@ -30,7 +30,7 @@ internal class RestEndpointTemplateTest {
 
   @Test
   fun `searchByIsbn, toString method`(): Unit = runTest {
-    RestEndpointTemplate.parse(TypicalLibraryBookApi.SearchByIsbn::class).toString()
+    RestEndpointTemplate.from(TypicalLibraryBookApi.SearchByIsbn::class).toString()
       .shouldBe(
         "RestEndpointTemplate([ -> application/json]" +
           " GET library/library-books (isbn))",
@@ -39,7 +39,7 @@ internal class RestEndpointTemplateTest {
 
   @Test
   fun `searchByTitle, toString method`(): Unit = runTest {
-    RestEndpointTemplate.parse(TypicalLibraryBookApi.SearchByText::class).toString()
+    RestEndpointTemplate.from(TypicalLibraryBookApi.SearchByText::class).toString()
       .shouldBe(
         "RestEndpointTemplate([ -> application/json]" +
           " GET library/library-books (title?, author?))",
@@ -48,7 +48,7 @@ internal class RestEndpointTemplateTest {
 
   @Test
   fun `create, toString method`(): Unit = runTest {
-    RestEndpointTemplate.parse(TypicalLibraryBookApi.Create::class).toString()
+    RestEndpointTemplate.from(TypicalLibraryBookApi.Create::class).toString()
       .shouldBe(
         "RestEndpointTemplate([application/json -> application/json]" +
           " POST library/library-books)",
@@ -57,7 +57,7 @@ internal class RestEndpointTemplateTest {
 
   @Test
   fun `update, toString method`(): Unit = runTest {
-    RestEndpointTemplate.parse(TypicalLibraryBookApi.Update::class).toString()
+    RestEndpointTemplate.from(TypicalLibraryBookApi.Update::class).toString()
       .shouldBe(
         "RestEndpointTemplate([application/json -> application/json]" +
           " PATCH library/library-books/:libraryBookId)",
@@ -66,7 +66,7 @@ internal class RestEndpointTemplateTest {
 
   @Test
   fun `delete, toString method`(): Unit = runTest {
-    RestEndpointTemplate.parse(TypicalLibraryBookApi.Delete::class).toString()
+    RestEndpointTemplate.from(TypicalLibraryBookApi.Delete::class).toString()
       .shouldBe(
         "RestEndpointTemplate([ -> application/json]" +
           " DELETE library/library-books/:libraryBookId)",

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/TypicalLibraryBookApi.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/TypicalLibraryBookApi.kt
@@ -3,9 +3,8 @@ package kairo.restFeature
 import kairo.id.KairoId
 
 /**
- * This API is used by [TypicalRestEndpointTemplateTest] which tests typical (happy path) cases.
- *
- * It's also used by [PrettyRestEndpointWriterTest].
+ * This API is used by many tests within the REST Feature.
+ * Verify all usages if making changes.
  */
 internal object TypicalLibraryBookApi {
   @RestEndpoint.Method("GET")

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/TypicalRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/TypicalRestEndpointTemplateTest.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test
 internal class TypicalRestEndpointTemplateTest {
   @Test
   fun get(): Unit = runTest {
-    RestEndpointTemplate.parse(TypicalLibraryBookApi.Get::class)
+    RestEndpointTemplate.from(TypicalLibraryBookApi.Get::class)
       .shouldBe(
         RestEndpointTemplate(
           method = HttpMethod.Get,
@@ -30,7 +30,7 @@ internal class TypicalRestEndpointTemplateTest {
 
   @Test
   fun listAll(): Unit = runTest {
-    RestEndpointTemplate.parse(TypicalLibraryBookApi.ListAll::class)
+    RestEndpointTemplate.from(TypicalLibraryBookApi.ListAll::class)
       .shouldBe(
         RestEndpointTemplate(
           method = HttpMethod.Get,
@@ -47,7 +47,7 @@ internal class TypicalRestEndpointTemplateTest {
 
   @Test
   fun searchByIsbn(): Unit = runTest {
-    RestEndpointTemplate.parse(TypicalLibraryBookApi.SearchByIsbn::class)
+    RestEndpointTemplate.from(TypicalLibraryBookApi.SearchByIsbn::class)
       .shouldBe(
         RestEndpointTemplate(
           method = HttpMethod.Get,
@@ -66,7 +66,7 @@ internal class TypicalRestEndpointTemplateTest {
 
   @Test
   fun searchByTitle(): Unit = runTest {
-    RestEndpointTemplate.parse(TypicalLibraryBookApi.SearchByText::class)
+    RestEndpointTemplate.from(TypicalLibraryBookApi.SearchByText::class)
       .shouldBe(
         RestEndpointTemplate(
           method = HttpMethod.Get,
@@ -86,7 +86,7 @@ internal class TypicalRestEndpointTemplateTest {
 
   @Test
   fun create(): Unit = runTest {
-    RestEndpointTemplate.parse(TypicalLibraryBookApi.Create::class)
+    RestEndpointTemplate.from(TypicalLibraryBookApi.Create::class)
       .shouldBe(
         RestEndpointTemplate(
           method = HttpMethod.Post,
@@ -103,7 +103,7 @@ internal class TypicalRestEndpointTemplateTest {
 
   @Test
   fun update(): Unit = runTest {
-    RestEndpointTemplate.parse(TypicalLibraryBookApi.Update::class)
+    RestEndpointTemplate.from(TypicalLibraryBookApi.Update::class)
       .shouldBe(
         RestEndpointTemplate(
           method = HttpMethod.Patch,
@@ -121,7 +121,7 @@ internal class TypicalRestEndpointTemplateTest {
 
   @Test
   fun delete(): Unit = runTest {
-    RestEndpointTemplate.parse(TypicalLibraryBookApi.Delete::class)
+    RestEndpointTemplate.from(TypicalLibraryBookApi.Delete::class)
       .shouldBe(
         RestEndpointTemplate(
           method = HttpMethod.Delete,


### PR DESCRIPTION
### Summary

One of the great features of Kairo's REST Feature is its ability to automatically derive `Endpoint`s (commands) from Ktor's `RoutingCall`. This requires some JVM reflection, but significantly decreases boilerplate.

### Checklist

- [ ] Documentation (root README, Feature READMEs, KDoc, comments).
- [ ] Logging.
- [ ] Tests.
