### PR TITLE
Use Kotlin runTest util

### DIFF
--- a/.detekt/config.yaml
+++ b/.detekt/config.yaml
@@ -475,7 +475,7 @@ potential-bugs:
     active: true
   ImplicitUnitReturnType:
     active: true
-    allowExplicitReturnType: false
+    allowExplicitReturnType: true
   InvalidRange:
     active: true
   IteratorHasNextCallsNextMethod:

--- a/kairo-config/src/test/kotlin/kairo/config/ConfigLoaderTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/ConfigLoaderTest.kt
@@ -3,6 +3,7 @@
 package kairo.config
 
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 internal class ConfigLoaderTest {
@@ -32,55 +33,55 @@ internal class ConfigLoaderTest {
     )
 
   @Test
-  fun `basic config`() {
+  fun `basic config`(): Unit = runTest {
     ConfigLoader.load<TestConfig>("basic-config").shouldBe(testConfig)
   }
 
   @Test
-  fun `config with extra root property`() {
+  fun `config with extra root property`(): Unit = runTest {
     configLoadingShouldFail {
       ConfigLoader.load<TestConfig>("config-with-extra-root-property")
     }
   }
 
   @Test
-  fun `config with extra nested property`() {
+  fun `config with extra nested property`(): Unit = runTest {
     configLoadingShouldFail {
       ConfigLoader.load<TestConfig>("config-with-extra-nested-property")
     }
   }
 
   @Test
-  fun `config with missing root property`() {
+  fun `config with missing root property`(): Unit = runTest {
     configLoadingShouldFail {
       ConfigLoader.load<TestConfig>("config-with-missing-root-property")
     }
   }
 
   @Test
-  fun `config with missing nested property`() {
+  fun `config with missing nested property`(): Unit = runTest {
     configLoadingShouldFail {
       ConfigLoader.load<TestConfig>("config-with-missing-nested-property")
     }
   }
 
   @Test
-  fun `config with trivial extension`() {
+  fun `config with trivial extension`(): Unit = runTest {
     ConfigLoader.load<TestConfig>("config-with-trivial-extension").shouldBe(testConfig)
   }
 
   @Test
-  fun `config with extension`() {
+  fun `config with extension`(): Unit = runTest {
     ConfigLoader.load<TestConfig>("config-with-extension").shouldBe(testConfig)
   }
 
   @Test
-  fun `config with application`() {
+  fun `config with application`(): Unit = runTest {
     ConfigLoader.load<TestConfig>("config-with-application").shouldBe(testConfig)
   }
 
   @Test
-  fun `config with extension and application`() {
+  fun `config with extension and application`(): Unit = runTest {
     ConfigLoader.load<TestConfig>("config-with-application").shouldBe(testConfig)
   }
 }

--- a/kairo-darb/src/test/kotlin/kairo/darb/BooleanListEncoderTest.kt
+++ b/kairo-darb/src/test/kotlin/kairo/darb/BooleanListEncoderTest.kt
@@ -4,11 +4,12 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.throwable.shouldHaveMessage
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 internal class BooleanListEncoderTest {
   @Test
-  fun encode() {
+  fun encode(): Unit = runTest {
     BooleanListEncoder.encode(emptyList()).shouldBe("")
     BooleanListEncoder.encode(listOf(false)).shouldBe("0")
     BooleanListEncoder.encode(listOf(true)).shouldBe("1")
@@ -23,7 +24,7 @@ internal class BooleanListEncoderTest {
   }
 
   @Test
-  fun decode() {
+  fun decode(): Unit = runTest {
     BooleanListEncoder.decode("").shouldBeEmpty()
     BooleanListEncoder.decode("0").shouldBe(listOf(false))
     BooleanListEncoder.decode("1").shouldBe(listOf(true))

--- a/kairo-darb/src/test/kotlin/kairo/darb/DarbEncoderTest.kt
+++ b/kairo-darb/src/test/kotlin/kairo/darb/DarbEncoderTest.kt
@@ -4,11 +4,12 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.throwable.shouldHaveMessage
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 internal class DarbEncoderTest {
   @Test
-  fun encode() {
+  fun encode(): Unit = runTest {
     DarbEncoder.encode(emptyList()).shouldBe("0.")
     DarbEncoder.encode(listOf(false)).shouldBe("1.0")
     DarbEncoder.encode(listOf(true)).shouldBe("1.8")
@@ -24,7 +25,7 @@ internal class DarbEncoderTest {
   }
 
   @Test
-  fun `decode, happy path`() {
+  fun `decode, happy path`(): Unit = runTest {
     DarbEncoder.decode("0.").shouldBeEmpty()
     DarbEncoder.decode("1.0").shouldBe(listOf(false))
     DarbEncoder.decode("1.8").shouldBe(listOf(true))
@@ -42,7 +43,7 @@ internal class DarbEncoderTest {
   }
 
   @Test
-  fun `decode, error cases`() {
+  fun `decode, error cases`(): Unit = runTest {
     shouldThrow<IllegalArgumentException> { DarbEncoder.decode("") }
       .shouldHaveMessage("DARB must have 2 components.")
     shouldThrow<IllegalArgumentException> { DarbEncoder.decode("1.1.1") }

--- a/kairo-id-feature/src/test/kotlin/kairo/id/DeterministicKairoIdGeneratorTest.kt
+++ b/kairo-id-feature/src/test/kotlin/kairo/id/DeterministicKairoIdGeneratorTest.kt
@@ -1,6 +1,7 @@
 package kairo.id
 
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 internal class DeterministicKairoIdGeneratorTest {
@@ -8,7 +9,7 @@ internal class DeterministicKairoIdGeneratorTest {
     DeterministicKairoIdGenerator(prefix = "library_book")
 
   @Test
-  fun test() {
+  fun test(): Unit = runTest {
     idGenerator.generate().shouldBe(KairoId("library_book", "00000000"))
     idGenerator.generate().shouldBe(KairoId("library_book", "00000001"))
     idGenerator.generate().shouldBe(KairoId("library_book", "00000002"))

--- a/kairo-id-feature/src/test/kotlin/kairo/id/KairoIdSerializationTest.kt
+++ b/kairo-id-feature/src/test/kotlin/kairo/id/KairoIdSerializationTest.kt
@@ -5,19 +5,20 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.ObjectMapperFactory
 import kairo.serialization.ObjectMapperFormat
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 internal class KairoIdSerializationTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun serialize() {
+  fun serialize(): Unit = runTest {
     mapper.writeValueAsString(KairoId("library_book", "2eDS1sMt"))
       .shouldBe("\"library_book_2eDS1sMt\"")
   }
 
   @Test
-  fun deserialize() {
+  fun deserialize(): Unit = runTest {
     mapper.readValue<KairoId>("\"library_book_2eDS1sMt\"")
       .shouldBe(KairoId("library_book", "2eDS1sMt"))
   }

--- a/kairo-id-feature/src/test/kotlin/kairo/id/KairoIdTest.kt
+++ b/kairo-id-feature/src/test/kotlin/kairo/id/KairoIdTest.kt
@@ -4,23 +4,24 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.throwable.shouldHaveMessage
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 internal class KairoIdTest {
   @Test
-  fun prefix() {
+  fun prefix(): Unit = runTest {
     KairoId("library_book", "2eDS1sMt").prefix
       .shouldBe("library_book")
   }
 
   @Test
-  fun id() {
+  fun id(): Unit = runTest {
     KairoId("library_book", "2eDS1sMt").id
       .shouldBe("2eDS1sMt")
   }
 
   @Test
-  fun `equals method`() {
+  fun `equals method`(): Unit = runTest {
     KairoId("library_book", "2eDS1sMt")
       .shouldBe(KairoId("library_book", "2eDS1sMt"))
     KairoId("library_book", "2eDS1sMt")
@@ -30,7 +31,7 @@ internal class KairoIdTest {
   }
 
   @Test
-  fun `hashCode method`() {
+  fun `hashCode method`(): Unit = runTest {
     KairoId("library_book", "2eDS1sMt").hashCode()
       .shouldBe(KairoId("library_book", "2eDS1sMt").hashCode())
     KairoId("library_book", "2eDS1sMt").hashCode()
@@ -40,46 +41,46 @@ internal class KairoIdTest {
   }
 
   @Test
-  fun `toString method`() {
+  fun `toString method`(): Unit = runTest {
     KairoId("library_book", "2eDS1sMt").toString()
       .shouldBe("library_book_2eDS1sMt")
   }
 
   @Test
-  fun `fromString method, valid (typical)`() {
+  fun `fromString method, valid (typical)`(): Unit = runTest {
     KairoId.fromString("library_book_2eDS1sMt")
       .shouldBe(KairoId("library_book", "2eDS1sMt"))
   }
 
   @Test
-  fun `fromString method, valid (atypical)`() {
+  fun `fromString method, valid (atypical)`(): Unit = runTest {
     KairoId.fromString("library_bookbook")
       .shouldBe(KairoId("library", "bookbook")) // Looks odd but is valid.
   }
 
   @Test
-  fun `fromString method, invalid (extra ID)`() {
+  fun `fromString method, invalid (extra ID)`(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       KairoId.fromString("library_book_2eDS1sMt_2eDS1sMt")
     }.shouldHaveMessage("Invalid Kairo ID: library_book_2eDS1sMt_2eDS1sMt.")
   }
 
   @Test
-  fun `fromString method, invalid (kebab case)`() {
+  fun `fromString method, invalid (kebab case)`(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       KairoId.fromString("library-book-2eDS1sMt")
     }.shouldHaveMessage("Invalid Kairo ID: library-book-2eDS1sMt.")
   }
 
   @Test
-  fun `fromString method, invalid (capital letter)`() {
+  fun `fromString method, invalid (capital letter)`(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       KairoId.fromString("Library_book_2eDS1sMt")
     }.shouldHaveMessage("Invalid Kairo ID: Library_book_2eDS1sMt.")
   }
 
   @Test
-  fun `fromString method, invalid (invalid character)`() {
+  fun `fromString method, invalid (invalid character)`(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       KairoId.fromString("library_böok_2eDS1sMt")
     }.shouldHaveMessage("Invalid Kairo ID: library_böok_2eDS1sMt.")

--- a/kairo-id-feature/src/test/kotlin/kairo/id/RandomKairoIdGeneratorTest.kt
+++ b/kairo-id-feature/src/test/kotlin/kairo/id/RandomKairoIdGeneratorTest.kt
@@ -1,6 +1,7 @@
 package kairo.id
 
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 internal class RandomKairoIdGeneratorTest {
@@ -11,7 +12,7 @@ internal class RandomKairoIdGeneratorTest {
    * There's no great way to test randomness, so we just ensure there are no duplicates over 100,000 generations.
    */
   @Test
-  fun test() {
+  fun test(): Unit = runTest {
     List(100_000) { idGenerator.generate() }.distinct().size.shouldBe(100_000)
   }
 }

--- a/kairo-protected-string/src/test/kotlin/kairo/protectedString/ProtectedStringSerializationTest.kt
+++ b/kairo-protected-string/src/test/kotlin/kairo/protectedString/ProtectedStringSerializationTest.kt
@@ -5,18 +5,19 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.ObjectMapperFactory
 import kairo.serialization.ObjectMapperFormat
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 internal class ProtectedStringSerializationTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun serialize() {
+  fun serialize(): Unit = runTest {
     mapper.writeValueAsString(ProtectedString("1")).shouldBe("\"1\"")
   }
 
   @Test
-  fun deserialize() {
+  fun deserialize(): Unit = runTest {
     mapper.readValue<ProtectedString>("\"1\"").shouldBe(ProtectedString("1"))
   }
 }

--- a/kairo-protected-string/src/test/kotlin/kairo/protectedString/ProtectedStringTest.kt
+++ b/kairo-protected-string/src/test/kotlin/kairo/protectedString/ProtectedStringTest.kt
@@ -2,29 +2,30 @@ package kairo.protectedString
 
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 internal class ProtectedStringTest {
   @Test
-  fun value() {
+  fun value(): Unit = runTest {
     @OptIn(ProtectedString.Access::class)
     ProtectedString("1").value.shouldBe("1")
   }
 
   @Test
-  fun `equals method`() {
+  fun `equals method`(): Unit = runTest {
     ProtectedString("1").shouldBe(ProtectedString("1"))
     ProtectedString("1").shouldNotBe(ProtectedString("2"))
   }
 
   @Test
-  fun `hashCode method`() {
+  fun `hashCode method`(): Unit = runTest {
     ProtectedString("1").hashCode().shouldBe("1".hashCode())
     ProtectedString("1").hashCode().shouldNotBe("2".hashCode())
   }
 
   @Test
-  fun `toString method`() {
+  fun `toString method`(): Unit = runTest {
     ProtectedString("1").toString().shouldBe("REDACTED")
   }
 }

--- a/kairo-reflect/src/test/kotlin/kairo/reflect/TypeParamTest.kt
+++ b/kairo-reflect/src/test/kotlin/kairo/reflect/TypeParamTest.kt
@@ -3,6 +3,7 @@ package kairo.reflect
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlin.reflect.KClass
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 internal class TypeParamTest {
@@ -19,24 +20,24 @@ internal class TypeParamTest {
   }
 
   @Test
-  fun `abstract int subclass`() {
+  fun `abstract int subclass`(): Unit = runTest {
     AbstractExampleIntSubclass().typeParam.shouldBe(Int::class)
   }
 
   @Test
-  fun `abstract string subclass`() {
+  fun `abstract string subclass`(): Unit = runTest {
     AbstractExampleStringSubclass().typeParam.shouldBe(String::class)
   }
 
   @Test
-  fun `concrete int class`() {
+  fun `concrete int class`(): Unit = runTest {
     shouldThrow<NullPointerException> {
       ConcreteExampleClass<Int>()
     }
   }
 
   @Test
-  fun `concrete string class`() {
+  fun `concrete string class`(): Unit = runTest {
     shouldThrow<NullPointerException> {
       ConcreteExampleClass<String>()
     }

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenAcceptRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenAcceptRestEndpointTemplateTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.throwable.shouldHaveMessage
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -14,7 +15,7 @@ import org.junit.jupiter.api.Test
  */
 internal class BrokenAcceptRestEndpointTemplateTest {
   @Test
-  fun acceptPresentOnGet() {
+  fun acceptPresentOnGet(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenAcceptLibraryBookApi.AcceptNotPresentOnGet::class)
     }.shouldHaveMessage(
@@ -24,7 +25,7 @@ internal class BrokenAcceptRestEndpointTemplateTest {
   }
 
   @Test
-  fun acceptNotPresentOnPost() {
+  fun acceptNotPresentOnPost(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenAcceptLibraryBookApi.AcceptNotPresentOnPost::class)
     }.shouldHaveMessage(
@@ -37,7 +38,7 @@ internal class BrokenAcceptRestEndpointTemplateTest {
    * This is actually valid; an empty string means "Any" content type.
    */
   @Test
-  fun emptyAccept() {
+  fun emptyAccept(): Unit = runTest {
     RestEndpointTemplate.parse(BrokenAcceptLibraryBookApi.EmptyAccept::class)
       .shouldBe(
         RestEndpointTemplate(
@@ -55,7 +56,7 @@ internal class BrokenAcceptRestEndpointTemplateTest {
   }
 
   @Test
-  fun malformedAccept() {
+  fun malformedAccept(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenAcceptLibraryBookApi.MalformedAccept::class)
     }.shouldHaveMessage(

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenContentTypeRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenContentTypeRestEndpointTemplateTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.throwable.shouldHaveMessage
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -14,7 +15,7 @@ import org.junit.jupiter.api.Test
  */
 internal class BrokenContentTypeRestEndpointTemplateTest {
   @Test
-  fun contentTypePresentOnGet() {
+  fun contentTypePresentOnGet(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenContentTypeLibraryBookApi.ContentTypePresentOnGet::class)
     }.shouldHaveMessage(
@@ -24,7 +25,7 @@ internal class BrokenContentTypeRestEndpointTemplateTest {
   }
 
   @Test
-  fun contentTypeNotPresentOnPost() {
+  fun contentTypeNotPresentOnPost(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenContentTypeLibraryBookApi.ContentTypeNotPresentOnPost::class)
     }.shouldHaveMessage(
@@ -37,7 +38,7 @@ internal class BrokenContentTypeRestEndpointTemplateTest {
    * This is actually valid; an empty string means "Any" content type.
    */
   @Test
-  fun emptyContentType() {
+  fun emptyContentType(): Unit = runTest {
     RestEndpointTemplate.parse(BrokenContentTypeLibraryBookApi.EmptyContentType::class)
       .shouldBe(
         RestEndpointTemplate(
@@ -54,7 +55,7 @@ internal class BrokenContentTypeRestEndpointTemplateTest {
   }
 
   @Test
-  fun malformedContentType() {
+  fun malformedContentType(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenContentTypeLibraryBookApi.MalformedContentType::class)
     }.shouldHaveMessage(

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenMethodRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenMethodRestEndpointTemplateTest.kt
@@ -2,6 +2,7 @@ package kairo.restFeature
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.throwable.shouldHaveMessage
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -11,7 +12,7 @@ import org.junit.jupiter.api.Test
  */
 internal class BrokenMethodRestEndpointTemplateTest {
   @Test
-  fun missingMethod() {
+  fun missingMethod(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenMethodLibraryBookApi.MissingMethod::class)
     }.shouldHaveMessage(
@@ -21,7 +22,7 @@ internal class BrokenMethodRestEndpointTemplateTest {
   }
 
   @Test
-  fun emptyMethod() {
+  fun emptyMethod(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenMethodLibraryBookApi.EmptyMethod::class)
     }.shouldHaveMessage(
@@ -31,7 +32,7 @@ internal class BrokenMethodRestEndpointTemplateTest {
   }
 
   @Test
-  fun sync() {
+  fun sync(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenMethodLibraryBookApi.UnsupportedMethod::class)
     }.shouldHaveMessage(

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenParamRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenParamRestEndpointTemplateTest.kt
@@ -2,6 +2,7 @@ package kairo.restFeature
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.throwable.shouldHaveMessage
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -11,7 +12,7 @@ import org.junit.jupiter.api.Test
  */
 internal class BrokenParamRestEndpointTemplateTest {
   @Test
-  fun nonParamConstructorParameter() {
+  fun nonParamConstructorParameter(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenParamLibraryBookApi.NonParamConstructorParameter::class)
     }.shouldHaveMessage(
@@ -21,7 +22,7 @@ internal class BrokenParamRestEndpointTemplateTest {
   }
 
   @Test
-  fun bodyAsPathParam() {
+  fun bodyAsPathParam(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenParamLibraryBookApi.BodyAsPathParam::class)
     }.shouldHaveMessage(
@@ -31,7 +32,7 @@ internal class BrokenParamRestEndpointTemplateTest {
   }
 
   @Test
-  fun bodyAsQueryParam() {
+  fun bodyAsQueryParam(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenParamLibraryBookApi.BodyAsQueryParam::class)
     }.shouldHaveMessage(
@@ -41,7 +42,7 @@ internal class BrokenParamRestEndpointTemplateTest {
   }
 
   @Test
-  fun pathParamMarkedAsQueryParam() {
+  fun pathParamMarkedAsQueryParam(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenParamLibraryBookApi.PathParamMarkedAsQueryParam::class)
     }.shouldHaveMessage(
@@ -51,7 +52,7 @@ internal class BrokenParamRestEndpointTemplateTest {
   }
 
   @Test
-  fun queryParamMarkedAsPathParam() {
+  fun queryParamMarkedAsPathParam(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenParamLibraryBookApi.QueryParamMarkedAsPathParam::class)
     }.shouldHaveMessage(
@@ -61,7 +62,7 @@ internal class BrokenParamRestEndpointTemplateTest {
   }
 
   @Test
-  fun paramIsPathAndQuery() {
+  fun paramIsPathAndQuery(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenParamLibraryBookApi.ParamIsPathAndQuery::class)
     }.shouldHaveMessage(

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenPathRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenPathRestEndpointTemplateTest.kt
@@ -2,6 +2,7 @@ package kairo.restFeature
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.throwable.shouldHaveMessage
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -11,7 +12,7 @@ import org.junit.jupiter.api.Test
  */
 internal class BrokenPathRestEndpointTemplateTest {
   @Test
-  fun missingMethod() {
+  fun missingMethod(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenPathLibraryBookApi.MissingPath::class)
     }.shouldHaveMessage(
@@ -21,7 +22,7 @@ internal class BrokenPathRestEndpointTemplateTest {
   }
 
   @Test
-  fun emptyMethod() {
+  fun emptyMethod(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenPathLibraryBookApi.EmptyPath::class)
     }.shouldHaveMessage(
@@ -31,7 +32,7 @@ internal class BrokenPathRestEndpointTemplateTest {
   }
 
   @Test
-  fun pathMissingLeadingSlash() {
+  fun pathMissingLeadingSlash(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenPathLibraryBookApi.PathMissingLeadingSlash::class)
     }.shouldHaveMessage(
@@ -41,7 +42,7 @@ internal class BrokenPathRestEndpointTemplateTest {
   }
 
   @Test
-  fun malformedConstantPathComponent() {
+  fun malformedConstantPathComponent(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenPathLibraryBookApi.MalformedConstantPathComponent::class)
     }.shouldHaveMessage(
@@ -51,7 +52,7 @@ internal class BrokenPathRestEndpointTemplateTest {
   }
 
   @Test
-  fun malformedPathConstantComponent() {
+  fun malformedPathConstantComponent(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenPathLibraryBookApi.MalformedConstantPathComponent::class)
     }.shouldHaveMessage(
@@ -61,7 +62,7 @@ internal class BrokenPathRestEndpointTemplateTest {
   }
 
   @Test
-  fun malformedParamPathComponent() {
+  fun malformedParamPathComponent(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenPathLibraryBookApi.MalformedParamPathComponent::class)
     }.shouldHaveMessage(
@@ -71,7 +72,7 @@ internal class BrokenPathRestEndpointTemplateTest {
   }
 
   @Test
-  fun nullablePathParam() {
+  fun nullablePathParam(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenPathLibraryBookApi.NullablePathParam::class)
     }.shouldHaveMessage(
@@ -81,7 +82,7 @@ internal class BrokenPathRestEndpointTemplateTest {
   }
 
   @Test
-  fun optionalPathParam() {
+  fun optionalPathParam(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenPathLibraryBookApi.OptionalPathParam::class)
     }.shouldHaveMessage(
@@ -91,7 +92,7 @@ internal class BrokenPathRestEndpointTemplateTest {
   }
 
   @Test
-  fun duplicatePathParamInPath() {
+  fun duplicatePathParamInPath(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenPathLibraryBookApi.DuplicatePathParamInPath::class)
     }.shouldHaveMessage(
@@ -101,7 +102,7 @@ internal class BrokenPathRestEndpointTemplateTest {
   }
 
   @Test
-  fun pathParamInPathButNotInConstructor() {
+  fun pathParamInPathButNotInConstructor(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenPathLibraryBookApi.PathParamInPathButNotInConstructor::class)
     }.shouldHaveMessage(
@@ -111,7 +112,7 @@ internal class BrokenPathRestEndpointTemplateTest {
   }
 
   @Test
-  fun pathParamInConstructorButNotInPath() {
+  fun pathParamInConstructorButNotInPath(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenPathLibraryBookApi.PathParamInConstructorButNotInPath::class)
     }.shouldHaveMessage(

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenRestEndpointTemplateTest.kt
@@ -2,6 +2,7 @@ package kairo.restFeature
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.throwable.shouldHaveMessage
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -10,7 +11,7 @@ import org.junit.jupiter.api.Test
  */
 internal class BrokenRestEndpointTemplateTest {
   @Test
-  fun notDataClass() {
+  fun notDataClass(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenLibraryBookApi.NotDataClass::class)
     }.shouldHaveMessage(
@@ -20,7 +21,7 @@ internal class BrokenRestEndpointTemplateTest {
   }
 
   @Test
-  fun notDataObject() {
+  fun notDataObject(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenLibraryBookApi.NotDataObject::class)
     }.shouldHaveMessage(

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenTypeRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/BrokenTypeRestEndpointTemplateTest.kt
@@ -2,6 +2,7 @@ package kairo.restFeature
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.throwable.shouldHaveMessage
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -10,7 +11,7 @@ import org.junit.jupiter.api.Test
  */
 internal class BrokenTypeRestEndpointTemplateTest {
   @Test
-  fun getWithBodyNotProvided() {
+  fun getWithBodyNotProvided(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenTypeLibraryBookApi.GetWithBodyNotProvided::class)
     }.shouldHaveMessage(
@@ -20,7 +21,7 @@ internal class BrokenTypeRestEndpointTemplateTest {
   }
 
   @Test
-  fun getWithBodyProvided() {
+  fun getWithBodyProvided(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenTypeLibraryBookApi.GetWithBodyProvided::class)
     }.shouldHaveMessage(
@@ -30,7 +31,7 @@ internal class BrokenTypeRestEndpointTemplateTest {
   }
 
   @Test
-  fun postWithoutBodyNotProvided() {
+  fun postWithoutBodyNotProvided(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenTypeLibraryBookApi.PostWithoutBodyProvided::class)
     }.shouldHaveMessage(
@@ -40,7 +41,7 @@ internal class BrokenTypeRestEndpointTemplateTest {
   }
 
   @Test
-  fun postWithoutBodyProvided() {
+  fun postWithoutBodyProvided(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       RestEndpointTemplate.parse(BrokenTypeLibraryBookApi.PostWithoutBodyNotProvided::class)
     }.shouldHaveMessage(

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/KtorPathTemplateRestEndpointWriterTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/KtorPathTemplateRestEndpointWriterTest.kt
@@ -1,53 +1,54 @@
 package kairo.restFeature
 
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 internal class KtorPathTemplateRestEndpointWriterTest {
   @Test
-  fun get() {
+  fun get(): Unit = runTest {
     val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.Get::class)
     KtorPathTemplateRestEndpointWriter.write(template)
       .shouldBe("library/library-books/{libraryBookId}")
   }
 
   @Test
-  fun listAll() {
+  fun listAll(): Unit = runTest {
     val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.ListAll::class)
     KtorPathTemplateRestEndpointWriter.write(template)
       .shouldBe("library/library-books")
   }
 
   @Test
-  fun searchByIsbn() {
+  fun searchByIsbn(): Unit = runTest {
     val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.SearchByIsbn::class)
     KtorPathTemplateRestEndpointWriter.write(template)
       .shouldBe("library/library-books")
   }
 
   @Test
-  fun searchByTitle() {
+  fun searchByTitle(): Unit = runTest {
     val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.SearchByText::class)
     KtorPathTemplateRestEndpointWriter.write(template)
       .shouldBe("library/library-books")
   }
 
   @Test
-  fun create() {
+  fun create(): Unit = runTest {
     val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.Create::class)
     KtorPathTemplateRestEndpointWriter.write(template)
       .shouldBe("library/library-books")
   }
 
   @Test
-  fun update() {
+  fun update(): Unit = runTest {
     val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.Update::class)
     KtorPathTemplateRestEndpointWriter.write(template)
       .shouldBe("library/library-books/{libraryBookId}")
   }
 
   @Test
-  fun delete() {
+  fun delete(): Unit = runTest {
     val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.Delete::class)
     KtorPathTemplateRestEndpointWriter.write(template)
       .shouldBe("library/library-books/{libraryBookId}")

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/PrettyRestEndpointWriterTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/PrettyRestEndpointWriterTest.kt
@@ -1,53 +1,54 @@
 package kairo.restFeature
 
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 internal class PrettyRestEndpointWriterTest {
   @Test
-  fun get() {
+  fun get(): Unit = runTest {
     val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.Get::class)
     PrettyRestEndpointWriter.write(template)
       .shouldBe("[ -> application/json] GET library/library-books/:libraryBookId")
   }
 
   @Test
-  fun listAll() {
+  fun listAll(): Unit = runTest {
     val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.ListAll::class)
     PrettyRestEndpointWriter.write(template)
       .shouldBe("[ -> application/json] GET library/library-books")
   }
 
   @Test
-  fun searchByIsbn() {
+  fun searchByIsbn(): Unit = runTest {
     val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.SearchByIsbn::class)
     PrettyRestEndpointWriter.write(template)
       .shouldBe("[ -> application/json] GET library/library-books (isbn)")
   }
 
   @Test
-  fun searchByTitle() {
+  fun searchByTitle(): Unit = runTest {
     val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.SearchByText::class)
     PrettyRestEndpointWriter.write(template)
       .shouldBe("[ -> application/json] GET library/library-books (title?, author?)")
   }
 
   @Test
-  fun create() {
+  fun create(): Unit = runTest {
     val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.Create::class)
     PrettyRestEndpointWriter.write(template)
       .shouldBe("[application/json -> application/json] POST library/library-books")
   }
 
   @Test
-  fun update() {
+  fun update(): Unit = runTest {
     val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.Update::class)
     PrettyRestEndpointWriter.write(template)
       .shouldBe("[application/json -> application/json] PATCH library/library-books/:libraryBookId")
   }
 
   @Test
-  fun delete() {
+  fun delete(): Unit = runTest {
     val template = RestEndpointTemplate.parse(TypicalLibraryBookApi.Delete::class)
     PrettyRestEndpointWriter.write(template)
       .shouldBe("[ -> application/json] DELETE library/library-books/:libraryBookId")

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/RestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/RestEndpointTemplateTest.kt
@@ -1,6 +1,7 @@
 package kairo.restFeature
 
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -10,7 +11,7 @@ import org.junit.jupiter.api.Test
 @Suppress("NullableToStringCall") // False positive.
 internal class RestEndpointTemplateTest {
   @Test
-  fun `get, toString method`() {
+  fun `get, toString method`(): Unit = runTest {
     RestEndpointTemplate.parse(TypicalLibraryBookApi.Get::class).toString()
       .shouldBe(
         "RestEndpointTemplate([ -> application/json]" +
@@ -19,7 +20,7 @@ internal class RestEndpointTemplateTest {
   }
 
   @Test
-  fun `listAll, toString method`() {
+  fun `listAll, toString method`(): Unit = runTest {
     RestEndpointTemplate.parse(TypicalLibraryBookApi.ListAll::class).toString()
       .shouldBe(
         "RestEndpointTemplate([ -> application/json]" +
@@ -28,7 +29,7 @@ internal class RestEndpointTemplateTest {
   }
 
   @Test
-  fun `searchByIsbn, toString method`() {
+  fun `searchByIsbn, toString method`(): Unit = runTest {
     RestEndpointTemplate.parse(TypicalLibraryBookApi.SearchByIsbn::class).toString()
       .shouldBe(
         "RestEndpointTemplate([ -> application/json]" +
@@ -37,7 +38,7 @@ internal class RestEndpointTemplateTest {
   }
 
   @Test
-  fun `searchByTitle, toString method`() {
+  fun `searchByTitle, toString method`(): Unit = runTest {
     RestEndpointTemplate.parse(TypicalLibraryBookApi.SearchByText::class).toString()
       .shouldBe(
         "RestEndpointTemplate([ -> application/json]" +
@@ -46,7 +47,7 @@ internal class RestEndpointTemplateTest {
   }
 
   @Test
-  fun `create, toString method`() {
+  fun `create, toString method`(): Unit = runTest {
     RestEndpointTemplate.parse(TypicalLibraryBookApi.Create::class).toString()
       .shouldBe(
         "RestEndpointTemplate([application/json -> application/json]" +
@@ -55,7 +56,7 @@ internal class RestEndpointTemplateTest {
   }
 
   @Test
-  fun `update, toString method`() {
+  fun `update, toString method`(): Unit = runTest {
     RestEndpointTemplate.parse(TypicalLibraryBookApi.Update::class).toString()
       .shouldBe(
         "RestEndpointTemplate([application/json -> application/json]" +
@@ -64,7 +65,7 @@ internal class RestEndpointTemplateTest {
   }
 
   @Test
-  fun `delete, toString method`() {
+  fun `delete, toString method`(): Unit = runTest {
     RestEndpointTemplate.parse(TypicalLibraryBookApi.Delete::class).toString()
       .shouldBe(
         "RestEndpointTemplate([ -> application/json]" +

--- a/kairo-rest-feature/src/test/kotlin/kairo/restFeature/TypicalRestEndpointTemplateTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/restFeature/TypicalRestEndpointTemplateTest.kt
@@ -3,6 +3,7 @@ package kairo.restFeature
 import io.kotest.matchers.shouldBe
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -10,7 +11,7 @@ import org.junit.jupiter.api.Test
  */
 internal class TypicalRestEndpointTemplateTest {
   @Test
-  fun get() {
+  fun get(): Unit = runTest {
     RestEndpointTemplate.parse(TypicalLibraryBookApi.Get::class)
       .shouldBe(
         RestEndpointTemplate(
@@ -28,7 +29,7 @@ internal class TypicalRestEndpointTemplateTest {
   }
 
   @Test
-  fun listAll() {
+  fun listAll(): Unit = runTest {
     RestEndpointTemplate.parse(TypicalLibraryBookApi.ListAll::class)
       .shouldBe(
         RestEndpointTemplate(
@@ -45,7 +46,7 @@ internal class TypicalRestEndpointTemplateTest {
   }
 
   @Test
-  fun searchByIsbn() {
+  fun searchByIsbn(): Unit = runTest {
     RestEndpointTemplate.parse(TypicalLibraryBookApi.SearchByIsbn::class)
       .shouldBe(
         RestEndpointTemplate(
@@ -64,7 +65,7 @@ internal class TypicalRestEndpointTemplateTest {
   }
 
   @Test
-  fun searchByTitle() {
+  fun searchByTitle(): Unit = runTest {
     RestEndpointTemplate.parse(TypicalLibraryBookApi.SearchByText::class)
       .shouldBe(
         RestEndpointTemplate(
@@ -84,7 +85,7 @@ internal class TypicalRestEndpointTemplateTest {
   }
 
   @Test
-  fun create() {
+  fun create(): Unit = runTest {
     RestEndpointTemplate.parse(TypicalLibraryBookApi.Create::class)
       .shouldBe(
         RestEndpointTemplate(
@@ -101,7 +102,7 @@ internal class TypicalRestEndpointTemplateTest {
   }
 
   @Test
-  fun update() {
+  fun update(): Unit = runTest {
     RestEndpointTemplate.parse(TypicalLibraryBookApi.Update::class)
       .shouldBe(
         RestEndpointTemplate(
@@ -119,7 +120,7 @@ internal class TypicalRestEndpointTemplateTest {
   }
 
   @Test
-  fun delete() {
+  fun delete(): Unit = runTest {
     RestEndpointTemplate.parse(TypicalLibraryBookApi.Delete::class)
       .shouldBe(
         RestEndpointTemplate(

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/BooleanDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/BooleanDefaultObjectMapperTest.kt
@@ -3,6 +3,7 @@ package kairo.serialization
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -21,55 +22,55 @@ internal class BooleanDefaultObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, false`() {
+  fun `serialize, false`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(false)).shouldBe("{\"value\":false}")
   }
 
   @Test
-  fun `serialize, true`() {
+  fun `serialize, true`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(true)).shouldBe("{\"value\":true}")
   }
 
   @Test
-  fun `deserialize, false`() {
+  fun `deserialize, false`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": false }").shouldBe(MyClass(false))
   }
 
   @Test
-  fun `deserialize, true`() {
+  fun `deserialize, true`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": true }").shouldBe(MyClass(true))
   }
 
   @Test
-  fun `deserialize, null`() {
+  fun `deserialize, null`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": null }")
     }
   }
 
   @Test
-  fun `deserialize, missing`() {
+  fun `deserialize, missing`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{}")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, int`() {
+  fun `deserialize, wrong type, int`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": 0 }")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, float`() {
+  fun `deserialize, wrong type, float`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": 1.0 }")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, string`() {
+  fun `deserialize, wrong type, string`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"false\" }")
     }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/BooleanIsObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/BooleanIsObjectMapperTest.kt
@@ -3,6 +3,7 @@ package kairo.serialization
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -25,34 +26,34 @@ internal class BooleanIsObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, false`() {
+  fun `serialize, false`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(false)).shouldBe("{\"isValue\":false}")
   }
 
   @Test
-  fun `serialize, true`() {
+  fun `serialize, true`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(true)).shouldBe("{\"isValue\":true}")
   }
 
   @Test
-  fun `deserialize, false`() {
+  fun `deserialize, false`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"isValue\": false }").shouldBe(MyClass(false))
   }
 
   @Test
-  fun `deserialize, true`() {
+  fun `deserialize, true`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"isValue\": true }").shouldBe(MyClass(true))
   }
 
   @Test
-  fun `deserialize, null`() {
+  fun `deserialize, null`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"isValue\": null }")
     }
   }
 
   @Test
-  fun `deserialize, missing`() {
+  fun `deserialize, missing`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{}")
     }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/BooleanNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/BooleanNullableObjectMapperTest.kt
@@ -3,6 +3,7 @@ package kairo.serialization
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -21,37 +22,37 @@ internal class BooleanNullableObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, false`() {
+  fun `serialize, false`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(false)).shouldBe("{\"value\":false}")
   }
 
   @Test
-  fun `serialize, true`() {
+  fun `serialize, true`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(true)).shouldBe("{\"value\":true}")
   }
 
   @Test
-  fun `serialize, null`() {
+  fun `serialize, null`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(null)).shouldBe("{\"value\":null}")
   }
 
   @Test
-  fun `deserialize, false`() {
+  fun `deserialize, false`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": false }").shouldBe(MyClass(false))
   }
 
   @Test
-  fun `deserialize, true`() {
+  fun `deserialize, true`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": true }").shouldBe(MyClass(true))
   }
 
   @Test
-  fun `deserialize, null`() {
+  fun `deserialize, null`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": null }").shouldBe(MyClass(null))
   }
 
   @Test
-  fun `deserialize, missing`() {
+  fun `deserialize, missing`(): Unit = runTest {
     mapper.readValue<MyClass>("{}").shouldBe(MyClass(null))
   }
 }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/DoubleDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/DoubleDefaultObjectMapperTest.kt
@@ -3,6 +3,7 @@ package kairo.serialization
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -21,53 +22,53 @@ internal class DoubleDefaultObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, positive`() {
+  fun `serialize, positive`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(1.23)).shouldBe("{\"value\":1.23}")
   }
 
   @Test
-  fun `serialize, negative`() {
+  fun `serialize, negative`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(-1.23)).shouldBe("{\"value\":-1.23}")
   }
 
   @Test
-  fun `deserialize, positive`() {
+  fun `deserialize, positive`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": 1.23 }").shouldBe(MyClass(1.23))
   }
 
   @Test
-  fun `deserialize, negative`() {
+  fun `deserialize, negative`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": -1.23 }").shouldBe(MyClass(-1.23))
   }
 
   @Test
-  fun `deserialize, null`() {
+  fun `deserialize, null`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": null }")
     }
   }
 
   @Test
-  fun `deserialize, missing`() {
+  fun `deserialize, missing`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{}")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, int`() {
+  fun `deserialize, wrong type, int`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": 42 }").shouldBe(MyClass(42.0))
   }
 
   @Test
-  fun `deserialize, wrong type, string`() {
+  fun `deserialize, wrong type, string`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"1.23\" }")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, boolean`() {
+  fun `deserialize, wrong type, boolean`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": true }")
     }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/DoubleNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/DoubleNullableObjectMapperTest.kt
@@ -3,6 +3,7 @@ package kairo.serialization
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -21,37 +22,37 @@ internal class DoubleNullableObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, positive`() {
+  fun `serialize, positive`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(1.23)).shouldBe("{\"value\":1.23}")
   }
 
   @Test
-  fun `serialize, negative`() {
+  fun `serialize, negative`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(-1.23)).shouldBe("{\"value\":-1.23}")
   }
 
   @Test
-  fun `serialize, null`() {
+  fun `serialize, null`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(null)).shouldBe("{\"value\":null}")
   }
 
   @Test
-  fun `deserialize, positive`() {
+  fun `deserialize, positive`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": 1.23 }").shouldBe(MyClass(1.23))
   }
 
   @Test
-  fun `deserialize, negative`() {
+  fun `deserialize, negative`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": -1.23 }").shouldBe(MyClass(-1.23))
   }
 
   @Test
-  fun `deserialize, null`() {
+  fun `deserialize, null`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": null }").shouldBe(MyClass(null))
   }
 
   @Test
-  fun `deserialize, missing`() {
+  fun `deserialize, missing`(): Unit = runTest {
     mapper.readValue<MyClass>("{}").shouldBe(MyClass(null))
   }
 }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/FloatDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/FloatDefaultObjectMapperTest.kt
@@ -3,6 +3,7 @@ package kairo.serialization
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -21,53 +22,53 @@ internal class FloatDefaultObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, positive`() {
+  fun `serialize, positive`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(1.23F)).shouldBe("{\"value\":1.23}")
   }
 
   @Test
-  fun `serialize, negative`() {
+  fun `serialize, negative`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(-1.23F)).shouldBe("{\"value\":-1.23}")
   }
 
   @Test
-  fun `deserialize, positive`() {
+  fun `deserialize, positive`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": 1.23 }").shouldBe(MyClass(1.23F))
   }
 
   @Test
-  fun `deserialize, negative`() {
+  fun `deserialize, negative`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": -1.23 }").shouldBe(MyClass(-1.23F))
   }
 
   @Test
-  fun `deserialize, null`() {
+  fun `deserialize, null`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": null }")
     }
   }
 
   @Test
-  fun `deserialize, missing`() {
+  fun `deserialize, missing`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{}")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, int`() {
+  fun `deserialize, wrong type, int`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": 42 }").shouldBe(MyClass(42.0F))
   }
 
   @Test
-  fun `deserialize, wrong type, string`() {
+  fun `deserialize, wrong type, string`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"1.23\" }")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, boolean`() {
+  fun `deserialize, wrong type, boolean`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": true }")
     }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/FloatNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/FloatNullableObjectMapperTest.kt
@@ -3,6 +3,7 @@ package kairo.serialization
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -21,37 +22,37 @@ internal class FloatNullableObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, positive`() {
+  fun `serialize, positive`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(1.23F)).shouldBe("{\"value\":1.23}")
   }
 
   @Test
-  fun `serialize, negative`() {
+  fun `serialize, negative`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(-1.23F)).shouldBe("{\"value\":-1.23}")
   }
 
   @Test
-  fun `serialize, null`() {
+  fun `serialize, null`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(null)).shouldBe("{\"value\":null}")
   }
 
   @Test
-  fun `deserialize, positive`() {
+  fun `deserialize, positive`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": 1.23 }").shouldBe(MyClass(1.23F))
   }
 
   @Test
-  fun `deserialize, negative`() {
+  fun `deserialize, negative`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": -1.23 }").shouldBe(MyClass(-1.23F))
   }
 
   @Test
-  fun `deserialize, null`() {
+  fun `deserialize, null`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": null }").shouldBe(MyClass(null))
   }
 
   @Test
-  fun `deserialize, missing`() {
+  fun `deserialize, missing`(): Unit = runTest {
     mapper.readValue<MyClass>("{}").shouldBe(MyClass(null))
   }
 }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/InstantDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/InstantDefaultObjectMapperTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.Instant
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -22,157 +23,157 @@ internal class InstantDefaultObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, recent`() {
+  fun `serialize, recent`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(Instant.parse("2023-11-13T19:44:32.123456789Z")))
       .shouldBe("{\"value\":\"2023-11-13T19:44:32.123456789Z\"}")
   }
 
   @Test
-  fun `serialize, old`() {
+  fun `serialize, old`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(Instant.parse("0005-01-01T00:00:00.000000000Z")))
       .shouldBe("{\"value\":\"0005-01-01T00:00:00Z\"}")
   }
 
   @Test
-  fun `deserialize, recent`() {
+  fun `deserialize, recent`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"2023-11-13T19:44:32.123456789Z\" }")
       .shouldBe(MyClass(Instant.parse("2023-11-13T19:44:32.123456789Z")))
   }
 
   @Test
-  fun `deserialize, old`() {
+  fun `deserialize, old`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"0005-01-01T00:00:00Z\" }")
       .shouldBe(MyClass(Instant.parse("0005-01-01T00:00:00.000000000Z")))
   }
 
   @Test
-  fun `deserialize, null`() {
+  fun `deserialize, null`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": null }")
     }
   }
 
   @Test
-  fun `deserialize, missing`() {
+  fun `deserialize, missing`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{}")
     }
   }
 
   @Test
-  fun `deserialize, missing leading zero from year`() {
+  fun `deserialize, missing leading zero from year`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"1-02-03T19:44:32.123456789Z\" }")
     }
   }
 
   @Test
-  fun `deserialize, missing leading zero from month`() {
+  fun `deserialize, missing leading zero from month`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"2023-2-03T19:44:32.123456789Z\" }")
     }
   }
 
   @Test
-  fun `deserialize, missing leading zero from day`() {
+  fun `deserialize, missing leading zero from day`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"2023-02-3T19:44:32.123456789Z\" }")
     }
   }
 
   @Test
-  fun `deserialize, missing leading zero from hour`() {
+  fun `deserialize, missing leading zero from hour`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"2023-02-03T9:44:32.123456789Z\" }")
     }
   }
 
   @Test
-  fun `deserialize, missing leading zero from minute`() {
+  fun `deserialize, missing leading zero from minute`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"2023-02-03T19:4:32.123456789Z\" }")
     }
   }
 
   @Test
-  fun `deserialize, missing leading zero from second`() {
+  fun `deserialize, missing leading zero from second`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"2023-02-03T19:44:2.123456789Z\" }")
     }
   }
 
   @Test
-  fun `deserialize, nonexistent date (low month)`() {
+  fun `deserialize, nonexistent date (low month)`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"2023-00-03T19:44:32.123456789Z\" }")
     }
   }
 
   @Test
-  fun `deserialize, nonexistent date (high month)`() {
+  fun `deserialize, nonexistent date (high month)`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"2023-13-03T19:44:32.123456789Z\" }")
     }
   }
 
   @Test
-  fun `deserialize, nonexistent date (low day)`() {
+  fun `deserialize, nonexistent date (low day)`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"2023-02-00T19:44:32.123456789Z\" }")
     }
   }
 
   @Test
-  fun `deserialize, nonexistent date (high day)`() {
+  fun `deserialize, nonexistent date (high day)`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"2023-02-29T19:44:32.123456789Z\" }")
     }
   }
 
   @Test
-  fun `deserialize, nonexistent date (high hour)`() {
+  fun `deserialize, nonexistent date (high hour)`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"2023-02-03T24:44:32.123456789Z\" }")
     }
   }
 
   @Test
-  fun `deserialize, nonexistent date (high minute)`() {
+  fun `deserialize, nonexistent date (high minute)`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"2023-02-03T19:60:32.123456789Z\" }")
     }
   }
 
   @Test
-  fun `deserialize, nonexistent date (high second)`() {
+  fun `deserialize, nonexistent date (high second)`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"2023-02-03T19:44:60.123456789Z\" }")
     }
   }
 
   @Test
-  fun `deserialize, too much precision`() {
+  fun `deserialize, too much precision`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"2023-02-03T19:44:32.1234567890Z\" }")
     }
   }
 
   @Test
-  fun `deserialize, no time zone`() {
+  fun `deserialize, no time zone`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"2023-02-03T19:44:32.123456789\" }")
     }
   }
 
   @Test
-  fun `deserialize, non-UTC`() {
+  fun `deserialize, non-UTC`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"2023-02-03T19:44:32.123456789-07:00[America/Edmonton]\" }")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, number`() {
+  fun `deserialize, wrong type, number`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": 1699904672123 }")
     }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/InstantNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/InstantNullableObjectMapperTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.Instant
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -22,43 +23,43 @@ internal class InstantNullableObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, recent`() {
+  fun `serialize, recent`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(Instant.parse("2023-11-13T19:44:32.123456789Z")))
       .shouldBe("{\"value\":\"2023-11-13T19:44:32.123456789Z\"}")
   }
 
   @Test
-  fun `serialize, old`() {
+  fun `serialize, old`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(Instant.parse("0005-01-01T00:00:00.000000000Z")))
       .shouldBe("{\"value\":\"0005-01-01T00:00:00Z\"}")
   }
 
   @Test
-  fun `serialize, null`() {
+  fun `serialize, null`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(null))
       .shouldBe("{\"value\":null}")
   }
 
   @Test
-  fun `deserialize, recent`() {
+  fun `deserialize, recent`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"2023-11-13T19:44:32.123456789Z\" }")
       .shouldBe(MyClass(Instant.parse("2023-11-13T19:44:32.123456789Z")))
   }
 
   @Test
-  fun `deserialize, old`() {
+  fun `deserialize, old`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"0005-01-01T00:00:00Z\" }")
       .shouldBe(MyClass(Instant.parse("0005-01-01T00:00:00.000000000Z")))
   }
 
   @Test
-  fun `deserialize, null`() {
+  fun `deserialize, null`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": null }")
       .shouldBe(MyClass(null))
   }
 
   @Test
-  fun `deserialize, missing`() {
+  fun `deserialize, missing`(): Unit = runTest {
     mapper.readValue<MyClass>("{}")
       .shouldBe(MyClass(null))
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/IntDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/IntDefaultObjectMapperTest.kt
@@ -3,6 +3,7 @@ package kairo.serialization
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -21,55 +22,55 @@ internal class IntDefaultObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, positive`() {
+  fun `serialize, positive`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(42)).shouldBe("{\"value\":42}")
   }
 
   @Test
-  fun `serialize, negative`() {
+  fun `serialize, negative`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(-42)).shouldBe("{\"value\":-42}")
   }
 
   @Test
-  fun `deserialize, positive`() {
+  fun `deserialize, positive`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": 42 }").shouldBe(MyClass(42))
   }
 
   @Test
-  fun `deserialize, negative`() {
+  fun `deserialize, negative`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": -42 }").shouldBe(MyClass(-42))
   }
 
   @Test
-  fun `deserialize, null`() {
+  fun `deserialize, null`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": null }")
     }
   }
 
   @Test
-  fun `deserialize, missing`() {
+  fun `deserialize, missing`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{}")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, float`() {
+  fun `deserialize, wrong type, float`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": 1.23 }")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, string`() {
+  fun `deserialize, wrong type, string`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"42\" }")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, boolean`() {
+  fun `deserialize, wrong type, boolean`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": true }")
     }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/IntNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/IntNullableObjectMapperTest.kt
@@ -3,6 +3,7 @@ package kairo.serialization
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -21,37 +22,37 @@ internal class IntNullableObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, positive`() {
+  fun `serialize, positive`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(42)).shouldBe("{\"value\":42}")
   }
 
   @Test
-  fun `serialize, negative`() {
+  fun `serialize, negative`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(-42)).shouldBe("{\"value\":-42}")
   }
 
   @Test
-  fun `serialize, null`() {
+  fun `serialize, null`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(null)).shouldBe("{\"value\":null}")
   }
 
   @Test
-  fun `deserialize, positive`() {
+  fun `deserialize, positive`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": 42 }").shouldBe(MyClass(42))
   }
 
   @Test
-  fun `deserialize, negative`() {
+  fun `deserialize, negative`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": -42 }").shouldBe(MyClass(-42))
   }
 
   @Test
-  fun `deserialize, null`() {
+  fun `deserialize, null`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": null }").shouldBe(MyClass(null))
   }
 
   @Test
-  fun `deserialize, missing`() {
+  fun `deserialize, missing`(): Unit = runTest {
     mapper.readValue<MyClass>("{}").shouldBe(MyClass(null))
   }
 }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/JsonObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/JsonObjectMapperTest.kt
@@ -10,6 +10,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.util.Optional
 import kotlin.uuid.Uuid
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -122,12 +123,12 @@ internal class JsonObjectMapperTest {
   """.trimIndent()
 
   @Test
-  fun serialize() {
+  fun serialize(): Unit = runTest {
     mapper.writeValueAsString(myClass).shouldBe(string)
   }
 
   @Test
-  fun deserialize() {
+  fun deserialize(): Unit = runTest {
     mapper.readValue<MyClass>(string).shouldBe(myClass)
   }
 }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/LocalDateDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/LocalDateDefaultObjectMapperTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.LocalDate
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -22,94 +23,94 @@ internal class LocalDateDefaultObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, recent`() {
+  fun `serialize, recent`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(LocalDate.parse("2023-11-13")))
       .shouldBe("{\"value\":\"2023-11-13\"}")
   }
 
   @Test
-  fun `serialize, old`() {
+  fun `serialize, old`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(LocalDate.parse("0005-01-01")))
       .shouldBe("{\"value\":\"0005-01-01\"}")
   }
 
   @Test
-  fun `deserialize, recent`() {
+  fun `deserialize, recent`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"2023-11-13\" }")
       .shouldBe(MyClass(LocalDate.parse("2023-11-13")))
   }
 
   @Test
-  fun `deserialize, old`() {
+  fun `deserialize, old`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"0005-01-01\" }")
       .shouldBe(MyClass(LocalDate.parse("0005-01-01")))
   }
 
   @Test
-  fun `deserialize, null`() {
+  fun `deserialize, null`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": null }")
     }
   }
 
   @Test
-  fun `deserialize, missing`() {
+  fun `deserialize, missing`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{}")
     }
   }
 
   @Test
-  fun `deserialize, missing leading zero from year`() {
+  fun `deserialize, missing leading zero from year`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"1-02-03\" }")
     }
   }
 
   @Test
-  fun `deserialize, missing leading zero from month`() {
+  fun `deserialize, missing leading zero from month`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"2023-2-03\" }")
     }
   }
 
   @Test
-  fun `deserialize, missing leading zero from day`() {
+  fun `deserialize, missing leading zero from day`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"2023-02-3\" }")
     }
   }
 
   @Test
-  fun `deserialize, nonexistent date (low month)`() {
+  fun `deserialize, nonexistent date (low month)`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"2023-00-03\" }")
     }
   }
 
   @Test
-  fun `deserialize, nonexistent date (high month)`() {
+  fun `deserialize, nonexistent date (high month)`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"2023-13-03\" }")
     }
   }
 
   @Test
-  fun `deserialize, nonexistent date (low day)`() {
+  fun `deserialize, nonexistent date (low day)`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"2023-02-00\" }")
     }
   }
 
   @Test
-  fun `deserialize, nonexistent date (high day)`() {
+  fun `deserialize, nonexistent date (high day)`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"2023-02-29\" }")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, number`() {
+  fun `deserialize, wrong type, number`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": 20231113 }")
     }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/LocalDateNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/LocalDateNullableObjectMapperTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.LocalDate
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -22,43 +23,43 @@ internal class LocalDateNullableObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, recent`() {
+  fun `serialize, recent`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(LocalDate.parse("2023-11-13")))
       .shouldBe("{\"value\":\"2023-11-13\"}")
   }
 
   @Test
-  fun `serialize, old`() {
+  fun `serialize, old`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(LocalDate.parse("0005-01-01")))
       .shouldBe("{\"value\":\"0005-01-01\"}")
   }
 
   @Test
-  fun `serialize, null`() {
+  fun `serialize, null`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(null))
       .shouldBe("{\"value\":null}")
   }
 
   @Test
-  fun `deserialize, recent`() {
+  fun `deserialize, recent`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"2023-11-13\" }")
       .shouldBe(MyClass(LocalDate.parse("2023-11-13")))
   }
 
   @Test
-  fun `deserialize, old`() {
+  fun `deserialize, old`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"0005-01-01\" }")
       .shouldBe(MyClass(LocalDate.parse("0005-01-01")))
   }
 
   @Test
-  fun `deserialize, null`() {
+  fun `deserialize, null`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": null }")
       .shouldBe(MyClass(null))
   }
 
   @Test
-  fun `deserialize, missing`() {
+  fun `deserialize, missing`(): Unit = runTest {
     mapper.readValue<MyClass>("{}")
       .shouldBe(MyClass(null))
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/LongDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/LongDefaultObjectMapperTest.kt
@@ -3,6 +3,7 @@ package kairo.serialization
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -21,55 +22,55 @@ internal class LongDefaultObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, positive`() {
+  fun `serialize, positive`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(42L)).shouldBe("{\"value\":42}")
   }
 
   @Test
-  fun `serialize, negative`() {
+  fun `serialize, negative`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(-42L)).shouldBe("{\"value\":-42}")
   }
 
   @Test
-  fun `deserialize, positive`() {
+  fun `deserialize, positive`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": 42 }").shouldBe(MyClass(42L))
   }
 
   @Test
-  fun `deserialize, negative`() {
+  fun `deserialize, negative`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": -42 }").shouldBe(MyClass(-42L))
   }
 
   @Test
-  fun `deserialize, null`() {
+  fun `deserialize, null`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": null }")
     }
   }
 
   @Test
-  fun `deserialize, missing`() {
+  fun `deserialize, missing`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{}")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, float`() {
+  fun `deserialize, wrong type, float`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": 1.23 }")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, string`() {
+  fun `deserialize, wrong type, string`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"42\" }")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, boolean`() {
+  fun `deserialize, wrong type, boolean`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": true }")
     }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/LongNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/LongNullableObjectMapperTest.kt
@@ -3,6 +3,7 @@ package kairo.serialization
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -21,37 +22,37 @@ internal class LongNullableObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, positive`() {
+  fun `serialize, positive`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(42L)).shouldBe("{\"value\":42}")
   }
 
   @Test
-  fun `serialize, negative`() {
+  fun `serialize, negative`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(-42L)).shouldBe("{\"value\":-42}")
   }
 
   @Test
-  fun `serialize, null`() {
+  fun `serialize, null`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(null)).shouldBe("{\"value\":null}")
   }
 
   @Test
-  fun `deserialize, positive`() {
+  fun `deserialize, positive`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": 42 }").shouldBe(MyClass(42L))
   }
 
   @Test
-  fun `deserialize, negative`() {
+  fun `deserialize, negative`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": -42 }").shouldBe(MyClass(-42L))
   }
 
   @Test
-  fun `deserialize, null`() {
+  fun `deserialize, null`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": null }").shouldBe(MyClass(null))
   }
 
   @Test
-  fun `deserialize, missing`() {
+  fun `deserialize, missing`(): Unit = runTest {
     mapper.readValue<MyClass>("{}").shouldBe(MyClass(null))
   }
 }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/OptionalDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/OptionalDefaultObjectMapperTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.util.Optional
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -28,48 +29,48 @@ internal class OptionalDefaultObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, present`() {
+  fun `serialize, present`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(Optional.of(42))).shouldBe("{\"value\":42}")
   }
 
   @Test
-  fun `serialize, empty`() {
+  fun `serialize, empty`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(Optional.empty())).shouldBe("{\"value\":null}")
   }
 
   @Test
-  fun `deserialize, present`() {
+  fun `deserialize, present`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": 42 }").shouldBe(MyClass(Optional.of(42)))
   }
 
   @Test
-  fun `deserialize, null`() {
+  fun `deserialize, null`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": null }").shouldBe(MyClass(Optional.empty()))
   }
 
   @Test
-  fun `deserialize, missing`() {
+  fun `deserialize, missing`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{}")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, float`() {
+  fun `deserialize, wrong type, float`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": 1.23 }")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, string`() {
+  fun `deserialize, wrong type, string`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"42\" }")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, boolean`() {
+  fun `deserialize, wrong type, boolean`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": true }")
     }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/OptionalNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/OptionalNullableObjectMapperTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.util.Optional
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -28,32 +29,32 @@ internal class OptionalNullableObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, present`() {
+  fun `serialize, present`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(Optional.of(42))).shouldBe("{\"value\":42}")
   }
 
   @Test
-  fun `serialize, empty`() {
+  fun `serialize, empty`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(Optional.empty())).shouldBe("{\"value\":null}")
   }
 
   @Test
-  fun `serialize, null`() {
+  fun `serialize, null`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(null)).shouldBe("{}")
   }
 
   @Test
-  fun `deserialize, present`() {
+  fun `deserialize, present`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": 42 }").shouldBe(MyClass(Optional.of(42)))
   }
 
   @Test
-  fun `deserialize, null`() {
+  fun `deserialize, null`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": null }").shouldBe(MyClass(Optional.empty()))
   }
 
   @Test
-  fun `deserialize, missing`() {
+  fun `deserialize, missing`(): Unit = runTest {
     mapper.readValue<MyClass>("{}").shouldBe(MyClass(null))
   }
 }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/PolymorphismObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/PolymorphismObjectMapperTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
@@ -50,7 +51,7 @@ internal class PolymorphismObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, car`() {
+  fun `serialize, car`(): Unit = runTest {
     val vehicle = Vehicle.Car(model = "Ford", plate = "ABC 1234", capacity = 5)
     val string = "{\"type\":\"Car\",\"model\":\"Ford\",\"plate\":\"ABC 1234\",\"capacity\":5,\"wheels\":4}"
     mapper.writeValueAsString(vehicle).shouldBe(string)
@@ -58,7 +59,7 @@ internal class PolymorphismObjectMapperTest {
   }
 
   @Test
-  fun `serialize, motorcycle`() {
+  fun `serialize, motorcycle`(): Unit = runTest {
     val vehicle = Vehicle.Motorcycle(plate = "MVM 12")
     val string = "{\"type\":\"Motorcycle\",\"plate\":\"MVM 12\",\"model\":null,\"wheels\":2}"
     mapper.writeValueAsString(vehicle).shouldBe(string)
@@ -66,7 +67,7 @@ internal class PolymorphismObjectMapperTest {
   }
 
   @Test
-  fun `serialize, bicycle`() {
+  fun `serialize, bicycle`(): Unit = runTest {
     val vehicle = Vehicle.Bicycle
     val string = "{\"type\":\"Bicycle\",\"model\":null,\"wheels\":2}"
     mapper.writeValueAsString(vehicle).shouldBe(string)
@@ -74,7 +75,7 @@ internal class PolymorphismObjectMapperTest {
   }
 
   @Test
-  fun `deserialize, car`() {
+  fun `deserialize, car`(): Unit = runTest {
     val string = "{\"type\": \"Car\", \"capacity\": 5, \"plate\": \"ABC 1234\", \"model\": \"Ford\", \"wheels\": 2}"
     val vehicle = Vehicle.Car(model = "Ford", plate = "ABC 1234", capacity = 5)
     mapper.readValue<Vehicle.Car>(string).shouldBe(vehicle)
@@ -82,7 +83,7 @@ internal class PolymorphismObjectMapperTest {
   }
 
   @Test
-  fun `deserialize, motorcycle`() {
+  fun `deserialize, motorcycle`(): Unit = runTest {
     val string = "{\"type\": \"Motorcycle\", \"plate\": \"MVM 12\", \"model\": null, \"wheels\": 2}"
     val vehicle = Vehicle.Motorcycle(plate = "MVM 12")
     mapper.readValue<Vehicle.Motorcycle>(string).shouldBe(vehicle)
@@ -95,7 +96,7 @@ internal class PolymorphismObjectMapperTest {
    */
   @Disabled
   @Test
-  fun `deserialize, bicycle`() {
+  fun `deserialize, bicycle`(): Unit = runTest {
     val vehicle = Vehicle.Bicycle
     val string = "{\"type\": \"Bicycle\", \"model\": null, \"wheels\": 2}"
     mapper.readValue<Vehicle.Bicycle>(string).shouldBe(vehicle)

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/PrettyPrintObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/PrettyPrintObjectMapperTest.kt
@@ -1,6 +1,7 @@
 package kairo.serialization
 
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -16,7 +17,7 @@ internal class PrettyPrintObjectMapperTest {
   }
 
   @Test
-  fun `serialize, prettyPrint = false (default)`() {
+  fun `serialize, prettyPrint = false (default)`(): Unit = runTest {
     val mapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
     val myClass = MyClass(
       string = "s v",
@@ -28,7 +29,7 @@ internal class PrettyPrintObjectMapperTest {
   }
 
   @Test
-  fun `serialize, prettyPrint = true`() {
+  fun `serialize, prettyPrint = true`(): Unit = runTest {
     val mapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json) { prettyPrint = true }.build()
     val myClass = MyClass(
       string = "string value",

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/StringDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/StringDefaultObjectMapperTest.kt
@@ -3,6 +3,7 @@ package kairo.serialization
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -21,55 +22,55 @@ internal class StringDefaultObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, non-empty`() {
+  fun `serialize, non-empty`(): Unit = runTest {
     mapper.writeValueAsString(MyClass("true")).shouldBe("{\"value\":\"true\"}")
   }
 
   @Test
-  fun `serialize, empty`() {
+  fun `serialize, empty`(): Unit = runTest {
     mapper.writeValueAsString(MyClass("")).shouldBe("{\"value\":\"\"}")
   }
 
   @Test
-  fun `deserialize, non-empty`() {
+  fun `deserialize, non-empty`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"true\" }").shouldBe(MyClass("true"))
   }
 
   @Test
-  fun `deserialize, empty`() {
+  fun `deserialize, empty`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"\" }").shouldBe(MyClass(""))
   }
 
   @Test
-  fun `deserialize, null`() {
+  fun `deserialize, null`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": null }")
     }
   }
 
   @Test
-  fun `deserialize, missing`() {
+  fun `deserialize, missing`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{}")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, int`() {
+  fun `deserialize, wrong type, int`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": 1 }")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, float`() {
+  fun `deserialize, wrong type, float`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": 0.0 }")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, boolean`() {
+  fun `deserialize, wrong type, boolean`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": true }")
     }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/StringNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/StringNullableObjectMapperTest.kt
@@ -3,6 +3,7 @@ package kairo.serialization
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -21,37 +22,37 @@ internal class StringNullableObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, non-empty`() {
+  fun `serialize, non-empty`(): Unit = runTest {
     mapper.writeValueAsString(MyClass("true")).shouldBe("{\"value\":\"true\"}")
   }
 
   @Test
-  fun `serialize, empty`() {
+  fun `serialize, empty`(): Unit = runTest {
     mapper.writeValueAsString(MyClass("")).shouldBe("{\"value\":\"\"}")
   }
 
   @Test
-  fun `serialize, null`() {
+  fun `serialize, null`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(null)).shouldBe("{\"value\":null}")
   }
 
   @Test
-  fun `deserialize, non-empty`() {
+  fun `deserialize, non-empty`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"true\" }").shouldBe(MyClass("true"))
   }
 
   @Test
-  fun `deserialize, empty`() {
+  fun `deserialize, empty`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"\" }").shouldBe(MyClass(""))
   }
 
   @Test
-  fun `deserialize, null`() {
+  fun `deserialize, null`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": null }").shouldBe(MyClass(null))
   }
 
   @Test
-  fun `deserialize, missing`() {
+  fun `deserialize, missing`(): Unit = runTest {
     mapper.readValue<MyClass>("{}").shouldBe(MyClass(null))
   }
 }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/UnknownPropertyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/UnknownPropertyObjectMapperTest.kt
@@ -2,6 +2,7 @@ package kairo.serialization
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -14,7 +15,7 @@ internal class UnknownPropertyObjectMapperTest {
   )
 
   @Test
-  fun `unknown properties disallowed (default)`() {
+  fun `unknown properties disallowed (default)`(): Unit = runTest {
     val mapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"foo\": \"bar\", \"baz\": \"qux\" }")
@@ -22,7 +23,7 @@ internal class UnknownPropertyObjectMapperTest {
   }
 
   @Test
-  fun `unknown properties allowed`() {
+  fun `unknown properties allowed`(): Unit = runTest {
     val mapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json) {
       allowUnknownProperties = true
     }.build()

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/UuidDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/UuidDefaultObjectMapperTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kotlin.uuid.Uuid
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -22,75 +23,75 @@ internal class UuidDefaultObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, default`() {
+  fun `serialize, default`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(Uuid.parse("3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8")))
       .shouldBe("{\"value\":\"3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8\"}")
   }
 
   @Test
-  fun `deserialize, default`() {
+  fun `deserialize, default`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8\" }")
       .shouldBe(MyClass(Uuid.parse("3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8")))
   }
 
   @Test
-  fun `deserialize, null`() {
+  fun `deserialize, null`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": null }")
     }
   }
 
   @Test
-  fun `deserialize, missing`() {
+  fun `deserialize, missing`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{}")
     }
   }
 
   @Test
-  fun `deserialize, too short`() {
+  fun `deserialize, too short`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"3ec0a853-dae3-4ee1-abe2-0b9c7dee45f\" }")
     }
   }
 
   @Test
-  fun `deserialize, too long`() {
+  fun `deserialize, too long`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"3ec0a853-dae3-4ee1-abe2-0b9c7dee45f88\" }")
     }
   }
 
   @Test
-  fun `deserialize, missing dashes`() {
+  fun `deserialize, missing dashes`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"3ec0a853dae34ee1abe20b9c7dee45f8\" }")
     }
   }
 
   @Test
-  fun `deserialize, invalid character`() {
+  fun `deserialize, invalid character`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"3ec0a853-dae3-4ee1-abe2-0b9c7dee45fg\" }")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, int`() {
+  fun `deserialize, wrong type, int`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": 42 }")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, float`() {
+  fun `deserialize, wrong type, float`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": 1.23 }")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, boolean`() {
+  fun `deserialize, wrong type, boolean`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": true }")
     }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/UuidNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/UuidNullableObjectMapperTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kotlin.uuid.Uuid
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -22,31 +23,31 @@ internal class UuidNullableObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, default`() {
+  fun `serialize, default`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(Uuid.parse("3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8")))
       .shouldBe("{\"value\":\"3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8\"}")
   }
 
   @Test
-  fun `serialize, null`() {
+  fun `serialize, null`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(null))
       .shouldBe("{\"value\":null}")
   }
 
   @Test
-  fun `deserialize, default`() {
+  fun `deserialize, default`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8\" }")
       .shouldBe(MyClass(Uuid.parse("3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8")))
   }
 
   @Test
-  fun `deserialize, null`() {
+  fun `deserialize, null`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": null }")
       .shouldBe(MyClass(null))
   }
 
   @Test
-  fun `deserialize, missing`() {
+  fun `deserialize, missing`(): Unit = runTest {
     mapper.readValue<MyClass>("{}").shouldBe(MyClass(null))
   }
 }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/YamlObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/YamlObjectMapperTest.kt
@@ -10,6 +10,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.util.Optional
 import kotlin.uuid.Uuid
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -116,12 +117,12 @@ internal class YamlObjectMapperTest {
   """.trimIndent() + '\n'
 
   @Test
-  fun serialize() {
+  fun serialize(): Unit = runTest {
     mapper.writeValueAsString(myClass).shouldBe(string)
   }
 
   @Test
-  fun deserialize() {
+  fun deserialize(): Unit = runTest {
     mapper.readValue<MyClass>(string).shouldBe(myClass)
   }
 }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/ZoneIdDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/ZoneIdDefaultObjectMapperTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.ZoneId
 import java.time.ZoneOffset
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -23,13 +24,13 @@ internal class ZoneIdDefaultObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, UTC offset`() {
+  fun `serialize, UTC offset`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(ZoneOffset.UTC))
       .shouldBe("{\"value\":\"UTC\"}")
   }
 
   @Test
-  fun `serialize, UTC region`() {
+  fun `serialize, UTC region`(): Unit = runTest {
     serializationShouldFail {
       mapper.writeValueAsString(MyClass(ZoneId.of("UTC")))
         .shouldBe("{\"value\":\"UTC\"}")
@@ -37,52 +38,52 @@ internal class ZoneIdDefaultObjectMapperTest {
   }
 
   @Test
-  fun `serialize, non-UTC`() {
+  fun `serialize, non-UTC`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(ZoneId.of("America/Edmonton")))
       .shouldBe("{\"value\":\"America/Edmonton\"}")
   }
 
   @Test
-  fun `deserialize, UTC offset`() {
+  fun `deserialize, UTC offset`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"Z\" }")
       .shouldBe(MyClass(ZoneOffset.UTC))
   }
 
   @Test
-  fun `deserialize, UTC region`() {
+  fun `deserialize, UTC region`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"UTC\" }")
       .shouldBe(MyClass(ZoneOffset.UTC))
   }
 
   @Test
-  fun `deserialize, non-UTC`() {
+  fun `deserialize, non-UTC`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"America/Edmonton\" }")
       .shouldBe(MyClass(ZoneId.of("America/Edmonton")))
   }
 
   @Test
-  fun `deserialize, null`() {
+  fun `deserialize, null`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": null }")
     }
   }
 
   @Test
-  fun `deserialize, missing`() {
+  fun `deserialize, missing`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{}")
     }
   }
 
   @Test
-  fun `deserialize, nonexistent`() {
+  fun `deserialize, nonexistent`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": \"America/Calgary\" }")
     }
   }
 
   @Test
-  fun `deserialize, wrong type, number`() {
+  fun `deserialize, wrong type, number`(): Unit = runTest {
     serializationShouldFail {
       mapper.readValue<MyClass>("{ \"value\": 0 }")
     }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/ZoneIdNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/ZoneIdNullableObjectMapperTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.ZoneId
 import java.time.ZoneOffset
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -23,13 +24,13 @@ internal class ZoneIdNullableObjectMapperTest {
   private val mapper: JsonMapper = ObjectMapperFactory.builder(ObjectMapperFormat.Json).build()
 
   @Test
-  fun `serialize, UTC offset`() {
+  fun `serialize, UTC offset`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(ZoneOffset.UTC))
       .shouldBe("{\"value\":\"UTC\"}")
   }
 
   @Test
-  fun `serialize, UTC region`() {
+  fun `serialize, UTC region`(): Unit = runTest {
     serializationShouldFail {
       mapper.writeValueAsString(MyClass(ZoneId.of("UTC")))
         .shouldBe("{\"value\":\"UTC\"}")
@@ -37,43 +38,43 @@ internal class ZoneIdNullableObjectMapperTest {
   }
 
   @Test
-  fun `serialize, non-UTC`() {
+  fun `serialize, non-UTC`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(ZoneId.of("America/Edmonton")))
       .shouldBe("{\"value\":\"America/Edmonton\"}")
   }
 
   @Test
-  fun `serialize, null`() {
+  fun `serialize, null`(): Unit = runTest {
     mapper.writeValueAsString(MyClass(null))
       .shouldBe("{\"value\":null}")
   }
 
   @Test
-  fun `deserialize, UTC offset`() {
+  fun `deserialize, UTC offset`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"Z\" }")
       .shouldBe(MyClass(ZoneOffset.UTC))
   }
 
   @Test
-  fun `deserialize, UTC region`() {
+  fun `deserialize, UTC region`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"UTC\" }")
       .shouldBe(MyClass(ZoneOffset.UTC))
   }
 
   @Test
-  fun `deserialize, non-UTC`() {
+  fun `deserialize, non-UTC`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"America/Edmonton\" }")
       .shouldBe(MyClass(ZoneId.of("America/Edmonton")))
   }
 
   @Test
-  fun `deserialize, null`() {
+  fun `deserialize, null`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": null }")
       .shouldBe(MyClass(null))
   }
 
   @Test
-  fun `deserialize, missing`() {
+  fun `deserialize, missing`(): Unit = runTest {
     mapper.readValue<MyClass>("{}")
       .shouldBe(MyClass(null))
   }

--- a/kairo-server/src/test/kotlin/kairo/server/ServerTest.kt
+++ b/kairo-server/src/test/kotlin/kairo/server/ServerTest.kt
@@ -4,6 +4,7 @@ import io.mockk.spyk
 import io.mockk.verifyOrder
 import kairo.feature.Feature
 import kairo.feature.FeaturePriority
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
@@ -15,7 +16,7 @@ import org.junit.jupiter.api.Test
  */
 internal class ServerTest {
   @Test
-  fun server() {
+  fun server(): Unit = runTest {
     class TestFeature : Feature() {
       override val name: String = "TestFeature"
 

--- a/kairo-testing/README.md
+++ b/kairo-testing/README.md
@@ -25,14 +25,14 @@ dependencies {
 
 internal class YourTest {
   @Test
-  fun `test case 1`() {
+  fun `test case 1`(): Unit = runTest {
     shouldThrow<IllegalArgumentException> {
       doSomething("1")
     }
   }
 
   @Test
-  fun `test case 2`() {
+  fun `test case 2`(): Unit = runTest {
     doSomething("2").shouldBe("wonderful result!")
   }
 }


### PR DESCRIPTION
### Summary

The Kotlin `runTest` util allows `suspend` functions to be called, among other things. I had to disable a lint rule to make this work nicely.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
