### PR TITLE
Fix some bugs with dependency injection utils

### DIFF
--- a/kairo-dependency-injection/src/main/kotlin/kairo/dependencyInjection/Binder.kt
+++ b/kairo-dependency-injection/src/main/kotlin/kairo/dependencyInjection/Binder.kt
@@ -6,4 +6,4 @@ import com.google.inject.Binder
 import com.google.inject.binder.AnnotatedBindingBuilder
 
 public inline fun <reified T : Any> Binder.bind(): AnnotatedBindingBuilder<T> =
-  bind(T::class.java)
+  bind(type<T>())

--- a/kairo-dependency-injection/src/main/kotlin/kairo/dependencyInjection/Injector.kt
+++ b/kairo-dependency-injection/src/main/kotlin/kairo/dependencyInjection/Injector.kt
@@ -3,6 +3,7 @@
 package kairo.dependencyInjection
 
 import com.google.inject.Injector
+import com.google.inject.Key
 
 public inline fun <reified T : Any> Injector.getInstance(): T =
-  getInstance(T::class.java)
+  getInstance(Key.get(type<T>()))

--- a/kairo-dependency-injection/src/main/kotlin/kairo/dependencyInjection/PrivateBinder.kt
+++ b/kairo-dependency-injection/src/main/kotlin/kairo/dependencyInjection/PrivateBinder.kt
@@ -6,4 +6,4 @@ import com.google.inject.PrivateBinder
 import com.google.inject.binder.AnnotatedElementBuilder
 
 public inline fun <reified T : Any> PrivateBinder.expose(): AnnotatedElementBuilder =
-  expose(T::class.java)
+  expose(type<T>())


### PR DESCRIPTION
### Summary

We were previously calling `T::class.java` in some of the dependency injection utils, which doesn't work for generics. I've switched this to `type<T>()`, which works for generics.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
