### PR TITLE
Introduce lazy singletons

### DIFF
--- a/.detekt/config.yaml
+++ b/.detekt/config.yaml
@@ -581,6 +581,7 @@ style:
       - 'com.google.inject.Binder.bind' # Use the Kotlin overload.
       - 'com.google.inject.Injector.getInstance' # Use the Kotlin overload.
       - 'com.google.inject.PrivateBinder.expose' # Use the Kotlin overload.
+      - 'com.google.inject.binder.ScopedBindingBuilder.in' # Use the Kotlin overload.
       - 'com.google.inject.binder.LinkedBindingBuilder.to' # Use the Kotlin overload.
       - 'com.google.inject.binder.LinkedBindingBuilder.toConstructor' # Use the Kotlin overload.
       - 'com.google.inject.binder.LinkedBindingBuilder.toProvider' # Use the Kotlin overload.

--- a/kairo-dependency-injection/README.md
+++ b/kairo-dependency-injection/README.md
@@ -11,4 +11,12 @@ along with some utilities to make its use more idiomatic.
 
 ## Usage
 
-This Feature is not currently intended to be a direct dependency.
+### Step 1: Include the dependency
+
+```kotlin
+// build.gradle.kts
+
+dependencies {
+  testImplementation("kairo:kairo-dependency-injection:$kairoVersion")
+}
+```

--- a/kairo-dependency-injection/src/main/kotlin/kairo/dependencyInjection/AnnotatedBindingBuilder.kt
+++ b/kairo-dependency-injection/src/main/kotlin/kairo/dependencyInjection/AnnotatedBindingBuilder.kt
@@ -1,0 +1,14 @@
+@file:Suppress("ForbiddenMethodCall")
+
+package kairo.dependencyInjection
+
+import com.google.inject.Singleton
+import com.google.inject.binder.AnnotatedBindingBuilder
+
+/**
+ * Unlike the built-in [AnnotatedBindingBuilder.asEagerSingleton],
+ * this makes singletons explicitly lazy.
+ */
+public fun AnnotatedBindingBuilder<*>.asLazySingleton() {
+  `in`(Singleton::class.java)
+}

--- a/kairo-reflect/README.md
+++ b/kairo-reflect/README.md
@@ -14,17 +14,3 @@ dependencies {
   testImplementation("kairo:kairo-reflect:$kairoVersion")
 }
 ```
-
-### Step 2: Try out the `typeParam` util
-
-```kotlin
-// src/main/kotlin/yourPackage/.../YourFile.kt
-
-abstract class ExampleClass<T : Any> {
-  val typeParam: KClass<T> = typeParam(0, ExampleClass::class, this::class)
-}
-
-class ExampleIntSubclass : ExampleClass<Int>()
-
-ExampleIntSubclass().typeParam // This will be Int::class.
-```


### PR DESCRIPTION
### Summary

Guice's `.asEagerSingleton()` is, obviously, eager. This PR introduces `.asLazySingleton()` as a corollary.

It also updates some docs, as usual.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
