### PR TITLE
Finish MVP for REST handlers

### DIFF
--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestServer.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestServer.kt
@@ -17,7 +17,7 @@ private val logger: KLogger = KotlinLogging.logger {}
  */
 internal class RestServer @Inject constructor(
   private val config: RestConfig,
-  private val handlers: Set<RestHandler<*>>,
+  private val handlers: Set<RestHandler<*, *>>,
 ) {
   private var ktor: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
 

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/bindRestEndpoint.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/bindRestEndpoint.kt
@@ -10,8 +10,8 @@ import kairo.dependencyInjection.type
  * Binding REST endpoints uses a [Multibinder],
  * which allows multiple instances to be bound separately but injected together as a set.
  */
-public inline fun <reified Handler : RestHandler<*>> PrivateBinder.bindRestEndpoint() {
-  val multibinder = Multibinder.newSetBinder(this, type<RestHandler<*>>())
+public inline fun <reified Handler : RestHandler<*, *>> PrivateBinder.bindRestEndpoint() {
+  val multibinder = Multibinder.newSetBinder(this, type<RestHandler<*, *>>())
   multibinder.addBinding().toClass(Handler::class)
-  expose<Set<RestHandler<*>>>()
+  expose<Set<RestHandler<*, *>>>()
 }

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/createModule.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/createModule.kt
@@ -20,7 +20,7 @@ private val logger: KLogger = KotlinLogging.logger {}
  * Kairo does not use Ktor's module system.
  * [createModule] returns a function that sets up a single module.
  */
-internal fun createModule(handlers: Set<RestHandler<*>>): Application.() -> Unit {
+internal fun createModule(handlers: Set<RestHandler<*, *>>): Application.() -> Unit {
   return {
     logger.info { "Registering ${handlers.size} REST handlers." }
     handlers.forEach { handler ->


### PR DESCRIPTION
### Summary

Part of #29. This allows very basic REST handlers to work! I needed to add a second type param unfortunately, in order to get `handle()` return types working correctly.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
