### PR TITLE
Rename Kairo Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Kairo is an application framework built for Kotlin.
 - [kairo-logging](kairo-logging/):
   Logging uses the [kotlin-logging](https://github.com/oshai/kotlin-logging) interface,
   which should be configured to use Apache Log4j2 under the hood.
+- [kairo-logging-feature](kairo-logging-feature/):
+  This Feature supports logging within Kairo Servers.
 - [kairo-protected-string](kairo-protected-string/):
   `ProtectedString` represents a string value that should not be logged or otherwise exposed.
 - [kairo-reflect](kairo-reflect/):
@@ -156,7 +158,7 @@ you'll need to configure some basic properties like `featureManager` and `restFe
 
 data class MonolithServerConfig(
   val featureManager: FeatureManagerConfig,
-  val restFeature: RestConfig,
+  val restFeature: KairoRestConfig,
 )
 ```
 
@@ -192,8 +194,9 @@ class MonolithServer(
   override val featureManager: FeatureManager =
     FeatureManager(
       features = setOf(
+        KairoRestFeature(config.restFeature),
+
         LibraryFeature(),
-        RestFeature(config.restFeature),
       ),
       config = config.featureManager,
     )

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ you'll need to configure some basic properties like `featureManager` and `restFe
 
 data class MonolithServerConfig(
   val featureManager: FeatureManagerConfig,
-  val restFeature: KairoRestConfig,
+  val rest: KairoRestConfig,
 )
 ```
 
@@ -170,7 +170,7 @@ featureManager:
     startupDelayMs: 2000 # 2 seconds.
     shutdownDelayMs: 4000 # 4 seconds.
 
-restFeature:
+rest:
   connector:
     host: "0.0.0.0"
     port: 8080
@@ -194,7 +194,7 @@ class MonolithServer(
   override val featureManager: FeatureManager =
     FeatureManager(
       features = setOf(
-        KairoRestFeature(config.restFeature),
+        KairoRestFeature(config.rest),
 
         LibraryFeature(),
       ),

--- a/kairo-logging-feature/src/main/kotlin/kairo/logging/KairoLoggingConfig.kt
+++ b/kairo-logging-feature/src/main/kotlin/kairo/logging/KairoLoggingConfig.kt
@@ -1,5 +1,5 @@
 package kairo.logging
 
-public data class LoggingConfig(
+public data class KairoLoggingConfig(
   val shutDownManually: Boolean,
 )

--- a/kairo-logging-feature/src/main/kotlin/kairo/logging/KairoLoggingFeature.kt
+++ b/kairo-logging-feature/src/main/kotlin/kairo/logging/KairoLoggingFeature.kt
@@ -5,8 +5,8 @@ import kairo.feature.Feature
 import kairo.feature.FeaturePriority
 import org.apache.logging.log4j.LogManager
 
-public class LoggingFeature(
-  private val config: LoggingConfig,
+public class KairoLoggingFeature(
+  private val config: KairoLoggingConfig,
 ) : Feature() {
   override val name: String = "Logging"
 

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/KairoRestConfig.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/KairoRestConfig.kt
@@ -2,7 +2,7 @@ package kairo.restFeature
 
 import io.ktor.server.engine.ApplicationEngine
 
-public data class RestConfig(
+public data class KairoRestConfig(
   val connector: Connector,
   val lifecycle: Lifecycle,
   val parallelism: Parallelism,

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/KairoRestFeature.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/KairoRestFeature.kt
@@ -8,15 +8,15 @@ import kairo.dependencyInjection.getInstance
 import kairo.feature.Feature
 import kairo.feature.FeaturePriority
 
-public class RestFeature(
-  private val config: RestConfig,
+public class KairoRestFeature(
+  private val config: KairoRestConfig,
 ) : Feature() {
   override val name: String = "REST"
 
   override val priority: FeaturePriority = FeaturePriority.Framework
 
   override fun bind(binder: PrivateBinder) {
-    binder.bind<RestConfig>().toInstance(config)
+    binder.bind<KairoRestConfig>().toInstance(config)
 
     binder.bind<RestServer>().asEagerSingleton()
     binder.expose<RestServer>()

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestServer.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/RestServer.kt
@@ -16,7 +16,7 @@ private val logger: KLogger = KotlinLogging.logger {}
  * adding support for easy [start] and [stop].
  */
 internal class RestServer @Inject constructor(
-  private val config: RestConfig,
+  private val config: KairoRestConfig,
   private val handlers: Set<RestHandler<*, *>>,
 ) {
   private var ktor: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null

--- a/kairo-rest-feature/src/main/kotlin/kairo/restFeature/configureEmbeddedServer.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/restFeature/configureEmbeddedServer.kt
@@ -4,7 +4,7 @@ import io.ktor.server.engine.ApplicationEngine
 import io.ktor.server.engine.connector
 
 internal fun <TConfiguration : ApplicationEngine.Configuration> configureEmbeddedServer(
-  config: RestConfig,
+  config: KairoRestConfig,
 ): TConfiguration.() -> Unit {
   return {
     applyConnector(config.connector)
@@ -14,7 +14,7 @@ internal fun <TConfiguration : ApplicationEngine.Configuration> configureEmbedde
 }
 
 private fun ApplicationEngine.Configuration.applyConnector(
-  config: RestConfig.Connector,
+  config: KairoRestConfig.Connector,
 ) {
   connector {
     host = config.host
@@ -23,14 +23,14 @@ private fun ApplicationEngine.Configuration.applyConnector(
 }
 
 private fun ApplicationEngine.Configuration.applyLifecycle(
-  config: RestConfig.Lifecycle,
+  config: KairoRestConfig.Lifecycle,
 ) {
   shutdownGracePeriod = config.shutdownGracePeriodMs
   shutdownTimeout = config.shutdownTimeoutMs
 }
 
 private fun ApplicationEngine.Configuration.applyParallelism(
-  config: RestConfig.Parallelism,
+  config: KairoRestConfig.Parallelism,
 ) {
   connectionGroupSize = config.connectionGroupSize
   workerGroupSize = config.workerGroupSize

--- a/kairo-server/README.md
+++ b/kairo-server/README.md
@@ -24,14 +24,14 @@ This example is a monolith.
 
 First, create the config class and YAML.
 Regardless of whether you're building a monolith or microservices,
-you'll need to configure some basic properties like `featureManager` and `restFeature`.
+you'll need to configure some basic properties like `featureManager` and `rest`.
 
 ```kotlin
 // src/main/kotlin/yourPackage/server/monolith/MonolithServerConfig.kt
 
 data class MonolithServerConfig(
   val featureManager: FeatureManagerConfig,
-  val restFeature: KairoRestConfig,
+  val rest: KairoRestConfig,
 )
 ```
 
@@ -41,7 +41,7 @@ featureManager:
     startupDelayMs: 2000 # 2 seconds.
     shutdownDelayMs: 4000 # 4 seconds.
 
-restFeature:
+rest:
   connector:
     host: "0.0.0.0"
     port: 8080
@@ -65,7 +65,7 @@ class MonolithServer(
   override val featureManager: FeatureManager =
     FeatureManager(
       features = setOf(
-        KairoRestFeature(config.restFeature),
+        KairoRestFeature(config.rest),
 
         LibraryFeature(),
       ),

--- a/kairo-server/README.md
+++ b/kairo-server/README.md
@@ -31,7 +31,7 @@ you'll need to configure some basic properties like `featureManager` and `restFe
 
 data class MonolithServerConfig(
   val featureManager: FeatureManagerConfig,
-  val restFeature: RestConfig,
+  val restFeature: KairoRestConfig,
 )
 ```
 
@@ -65,8 +65,9 @@ class MonolithServer(
   override val featureManager: FeatureManager =
     FeatureManager(
       features = setOf(
+        KairoRestFeature(config.restFeature),
+
         LibraryFeature(),
-        RestFeature(config.restFeature),
       ),
       config = config.featureManager,
     )


### PR DESCRIPTION
### Summary

Let's prefix Kairo Features with `Kairo`, so that library users can easily differentiate them from their own Features.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
