### PR TITLE
Turn off unused Detekt features

### DIFF
--- a/.detekt/config.yaml
+++ b/.detekt/config.yaml
@@ -12,12 +12,33 @@ config:
 
 processors:
   active: false
+  exclude:
+#    - 'DetektProgressListener'
+    - 'KtFileCountProcessor'
+    - 'PackageCountProcessor'
+    - 'ClassCountProcessor'
+    - 'FunctionCountProcessor'
+    - 'PropertyCountProcessor'
+    - 'ProjectComplexityProcessor'
+    - 'ProjectCognitiveComplexityProcessor'
+    - 'ProjectLLOCProcessor'
+    - 'ProjectCLOCProcessor'
+    - 'ProjectLOCProcessor'
+    - 'ProjectSLOCProcessor'
+    - 'LicenseHeaderLoaderExtension'
 
 console-reports:
   active: true
+  exclude:
+#    - 'ProjectStatisticsReport'
+#    - 'ComplexityReport'
+#    - 'NotificationReport'
+#    - 'FindingsReport'
+    - 'FileBasedFindingsReport'
+#    - 'LiteFindingsReport'
 
 output-reports:
-  active: true
+  active: false
 
 comments:
   AbsentOrWrongFileLicense:


### PR DESCRIPTION
### Summary

A bunch of extra Detekt reports/outputs/stuff were enabled that we don't need.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
