### PR TITLE
Fix bug with nested config extension

### DIFF
--- a/kairo-config/src/main/kotlin/kairo/config/ConfigLoader.kt
+++ b/kairo-config/src/main/kotlin/kairo/config/ConfigLoader.kt
@@ -63,7 +63,7 @@ public object ConfigLoader {
     val apply = extractApply(config)
     var result = config
     if (extends != null) {
-      result = simpleLoadAsJson(extends)
+      result = loadAsJson(extends)
     }
     apply?.forEach { merge(result, loadAsJson(it)) }
     if (extends != null) {


### PR DESCRIPTION
### Summary

There was a bug where a config that extended a config that extended another config would not be loaded properly.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
