### PR TITLE
Fix mistakes with lazy singleton provider

### DIFF
--- a/kairo-dependency-injection/build.gradle.kts
+++ b/kairo-dependency-injection/build.gradle.kts
@@ -4,5 +4,7 @@ plugins {
 }
 
 dependencies {
+  implementation(project(":kairo-reflect"))
+
   api(libs.guice)
 }

--- a/kairo-dependency-injection/src/main/kotlin/kairo/dependencyInjection/LazySingletonProvider.kt
+++ b/kairo-dependency-injection/src/main/kotlin/kairo/dependencyInjection/LazySingletonProvider.kt
@@ -1,14 +1,23 @@
 package kairo.dependencyInjection
 
 import com.google.inject.Provider
+import com.google.inject.Singleton
+import kotlin.reflect.full.hasAnnotation
 
 /**
- * Leverages Kotlin's [Lazy] to implement a singleton provider that is lazily initialized.
+ * Leverages Kotlin's [Lazy] to implement a provider that is lazily initialized.
+ * This provider must always have the [Singleton] annotation
  *
  * This should be used with care,
  * since its use can lead to deferring expensive operations beyond Server startup.
  */
 public abstract class LazySingletonProvider<T : Any> : Provider<T> {
+  init {
+    require(this::class.hasAnnotation<Singleton>()) {
+      "Instances of ${LazySingletonProvider::class.simpleName!!} require @${Singleton::class.simpleName!!}."
+    }
+  }
+
   private val value: Lazy<T> = lazy(::create)
 
   final override fun get(): T =

--- a/kairo-rest-feature/src/main/kotlin/kairo/rest/KtorServerProvider.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/rest/KtorServerProvider.kt
@@ -1,11 +1,13 @@
 package kairo.rest
 
 import com.google.inject.Inject
+import com.google.inject.Singleton
 import io.ktor.server.cio.CIO
 import io.ktor.server.engine.applicationEnvironment
 import io.ktor.server.engine.embeddedServer
 import kairo.dependencyInjection.LazySingletonProvider
 
+@Singleton
 internal class KtorServerProvider @Inject constructor(
   private val config: KairoRestConfig,
   private val handlers: Set<RestHandler<*, *>>,

--- a/kairo-rest-feature/src/main/kotlin/kairo/rest/RestClient.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/rest/RestClient.kt
@@ -8,7 +8,7 @@ public class RestClient @Inject constructor(
   public suspend fun <H : RestHandler<E, O>, E : RestEndpoint<I, O>, I : Any, O : Any?> request(endpoint: E): O {
     @Suppress("UNCHECKED_CAST")
     val handler = checkNotNull(registry[endpoint::class]) {
-      "REST handler registry had no entry for ${endpoint::class.simpleName!!}."
+      "REST handler registry had no entry for ${endpoint::class.qualifiedName!!}."
     } as H
     return handler.handle(endpoint)
   }

--- a/kairo-sql-feature/src/main/kotlin/kairo/sql/HikariDataSourceProvider.kt
+++ b/kairo-sql-feature/src/main/kotlin/kairo/sql/HikariDataSourceProvider.kt
@@ -1,11 +1,13 @@
 package kairo.sql
 
 import com.google.inject.Inject
+import com.google.inject.Singleton
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import kairo.dependencyInjection.LazySingletonProvider
 import kairo.protectedString.ProtectedString
 
+@Singleton
 public class HikariDataSourceProvider @Inject constructor(
   private val config: KairoSqlConfig,
 ) : LazySingletonProvider<HikariDataSource>() {


### PR DESCRIPTION
### Summary

There's no singleton logic built-in. We need to rely on the `@Singleton` annotation.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
