### PR TITLE
Create CommandRunner

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ class MonolithServer(
 }
 
 fun main() {
-  val config = ConfigLoader().load<MonolithServerConfig>("config")
+  val config = ConfigLoader.load<MonolithServerConfig>("config")
   val server = MonolithServer(config)
   server.start()
 }

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Each modules falls into one of 3 categories:
 
 ### Internal modules
 
+- [kairo-command-runner](kairo-command-runner/):
+  `CommandRunner` runs shell commands.
+  It delegates to Java's built-in way of doing this,
+  but uses an abstract class for testability.
 - [kairo-dependency-injection](kairo-dependency-injection/):
   Makes Guice available,
   along with some utilities to make its use more idiomatic.
@@ -317,7 +321,7 @@ class MonolithServer(
 }
 
 fun main() {
-  val config = ConfigLoader.load<MonolithServerConfig>("config")
+  val config = ConfigLoader().load<MonolithServerConfig>("config")
   val server = MonolithServer(config)
   server.start()
 }

--- a/kairo-command-runner/README.md
+++ b/kairo-command-runner/README.md
@@ -1,0 +1,28 @@
+# `kairo-comand-runner`
+
+`CommandRunner` runs shell commands.
+It delegates to Java's built-in way of doing this,
+but uses an abstract class for testability.
+
+This is not considered secure, and should not be used in production unless additional measures are in place.
+
+## Usage
+
+### Step 1: Include the dependency
+
+```kotlin
+// build.gradle.kts
+
+dependencies {
+  api("kairo:kairo-command-runner:$kairoVersion")
+}
+```
+
+### Step 2: Run a command
+
+```kotlin
+// src/main/kotlin/yourPackage/.../YourFile.kt
+
+val commandRunner: CommandRunner = DefaultCommandRunner
+commandRunner.run("echo \"Hello, World!\"") // Hello, World!
+```

--- a/kairo-command-runner/build.gradle.kts
+++ b/kairo-command-runner/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+  id("kairo")
+  id("kairo-publish")
+}
+
+dependencies {
+  implementation(project(":kairo-logging"))
+  implementation(project(":kairo-util"))
+
+  testImplementation(project(":kairo-logging:testing"))
+  testImplementation(project(":kairo-testing"))
+}

--- a/kairo-command-runner/src/main/kotlin/kairo/commandRunner/CommandRunner.kt
+++ b/kairo-command-runner/src/main/kotlin/kairo/commandRunner/CommandRunner.kt
@@ -1,0 +1,18 @@
+package kairo.commandRunner
+
+/**
+ * Runs shell commands.
+ * The default implementation ([DefaultCommandRunner]) delegates to Java's built-in way of doing this.
+ * This abstract class is for testability.
+ *
+ * This is NOT CONSIDERED SECURE, and should not be used in production unless additional measures are in place.
+ * To prevent insecure usage, opting into [Insecure] is necessary.
+ */
+public abstract class CommandRunner {
+  @RequiresOptIn
+  @Target(AnnotationTarget.FUNCTION)
+  public annotation class Insecure
+
+  @Insecure
+  public abstract fun run(command: String): String?
+}

--- a/kairo-command-runner/src/main/kotlin/kairo/commandRunner/DefaultCommandRunner.kt
+++ b/kairo-command-runner/src/main/kotlin/kairo/commandRunner/DefaultCommandRunner.kt
@@ -1,0 +1,16 @@
+package kairo.commandRunner
+
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val logger: KLogger = KotlinLogging.logger {}
+
+public object DefaultCommandRunner : CommandRunner() {
+  @Insecure
+  override fun run(command: String): String? {
+    logger.debug { "Running command: $command." }
+    val runtime = Runtime.getRuntime()
+    val result = runtime.exec(arrayOf("sh", "-c", command))
+    return result.inputReader().readLines().singleNullOrThrow()
+  }
+}

--- a/kairo-command-runner/src/test/kotlin/kairo/commandRunner/DefaultCommandRunnerTest.kt
+++ b/kairo-command-runner/src/test/kotlin/kairo/commandRunner/DefaultCommandRunnerTest.kt
@@ -1,0 +1,27 @@
+package kairo.commandRunner
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+@OptIn(CommandRunner.Insecure::class)
+internal class DefaultCommandRunnerTest {
+  private val commandRunner: CommandRunner = DefaultCommandRunner
+
+  @Test
+  fun `0 lines`() {
+    commandRunner.run(";").shouldBe(null)
+  }
+
+  @Test
+  fun `1 line`() {
+    commandRunner.run("echo \"Hello, World!\"").shouldBe("Hello, World!")
+  }
+
+  @Test
+  fun `2 lines`() {
+    shouldThrow<IllegalArgumentException> {
+      commandRunner.run("echo -e \"First\\nSecond\"")
+    }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,7 @@
 rootProject.name = "kairo"
 
 include(":kairo-clock-feature")
+include(":kairo-command-runner")
 include(":kairo-config")
 include(":kairo-darb")
 include(":kairo-dependency-injection")


### PR DESCRIPTION
### Summary

`CommandRunner` runs shell commands. It delegates to Java's built-in way of doing this, but uses an abstract class for testability.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
