### PR TITLE
Allow protected strings from environment variables if they're empty

### DIFF
--- a/kairo-config/src/main/kotlin/kairo/config/ConfigProtectedStringDeserializer.kt
+++ b/kairo-config/src/main/kotlin/kairo/config/ConfigProtectedStringDeserializer.kt
@@ -20,8 +20,9 @@ internal class ConfigProtectedStringDeserializer(
    */
   override fun deserialize(p: JsonParser, ctxt: DeserializationContext): ProtectedString? {
     if (p.currentToken in stringDeserializer.tokens) {
-      requireInsecure("plaintext")
-      return stringDeserializer.deserialize(p, ctxt)?.let { ProtectedString(it) }
+      val string = stringDeserializer.deserialize(p, ctxt)
+      if (!string.isNullOrEmpty()) requireInsecure("plaintext")
+      return string?.let { ProtectedString(it) }
     }
     return super.deserialize(p, ctxt)
   }

--- a/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderProtectedStringDefaultDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderProtectedStringDefaultDeserializerTest.kt
@@ -26,6 +26,12 @@ internal class PlaintextConfigLoaderProtectedStringDefaultDeserializerTest : Con
     }
   """.trimIndent()
 
+  private val emptyString: String = """
+    {
+      "message": ""
+    }
+  """.trimIndent()
+
   private val nullString = """
     {
       "message": null
@@ -46,6 +52,20 @@ internal class PlaintextConfigLoaderProtectedStringDefaultDeserializerTest : Con
     allowInsecureConfigSources(true)
     val mapper = createMapper()
     mapper.readValue<MyClass>(nonNullString).shouldBe(MyClass(ProtectedString("Hello, World!")))
+  }
+
+  @Test
+  fun `empty (allowInsecureConfigSources = false)`(): Unit = runTest {
+    allowInsecureConfigSources(false)
+    val mapper = createMapper()
+    mapper.readValue<MyClass>(emptyString).shouldBe(MyClass(ProtectedString("")))
+  }
+
+  @Test
+  fun `empty (allowInsecureConfigSources = true)`(): Unit = runTest {
+    allowInsecureConfigSources(true)
+    val mapper = createMapper()
+    mapper.readValue<MyClass>(emptyString).shouldBe(MyClass(ProtectedString("")))
   }
 
   @Test

--- a/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderProtectedStringNullableDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderProtectedStringNullableDeserializerTest.kt
@@ -26,6 +26,12 @@ internal class PlaintextConfigLoaderProtectedStringNullableDeserializerTest : Co
     }
   """.trimIndent()
 
+  private val emptyString: String = """
+    {
+      "message": ""
+    }
+  """.trimIndent()
+
   private val nullString = """
     {
       "message": null
@@ -46,6 +52,20 @@ internal class PlaintextConfigLoaderProtectedStringNullableDeserializerTest : Co
     allowInsecureConfigSources(true)
     val mapper = createMapper()
     mapper.readValue<MyClass>(nonNullString).shouldBe(MyClass(ProtectedString("Hello, World!")))
+  }
+
+  @Test
+  fun `empty (allowInsecureConfigSources = false)`(): Unit = runTest {
+    allowInsecureConfigSources(false)
+    val mapper = createMapper()
+    mapper.readValue<MyClass>(emptyString).shouldBe(MyClass(ProtectedString("")))
+  }
+
+  @Test
+  fun `empty (allowInsecureConfigSources = true)`(): Unit = runTest {
+    allowInsecureConfigSources(true)
+    val mapper = createMapper()
+    mapper.readValue<MyClass>(emptyString).shouldBe(MyClass(ProtectedString("")))
   }
 
   @Test

--- a/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderStringDefaultDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderStringDefaultDeserializerTest.kt
@@ -24,6 +24,12 @@ internal class PlaintextConfigLoaderStringDefaultDeserializerTest : ConfigLoader
     }
   """.trimIndent()
 
+  private val emptyString: String = """
+    {
+      "message": ""
+    }
+  """.trimIndent()
+
   private val nullString = """
     {
       "message": null
@@ -57,6 +63,20 @@ internal class PlaintextConfigLoaderStringDefaultDeserializerTest : ConfigLoader
     shouldThrow<JsonMappingException> {
       mapper.readValue<MyClass>(nullString)
     }
+  }
+
+  @Test
+  fun `empty (allowInsecureConfigSources = false)`(): Unit = runTest {
+    allowInsecureConfigSources(false)
+    val mapper = createMapper()
+    mapper.readValue<MyClass>(emptyString).shouldBe(MyClass(""))
+  }
+
+  @Test
+  fun `empty (allowInsecureConfigSources = true)`(): Unit = runTest {
+    allowInsecureConfigSources(true)
+    val mapper = createMapper()
+    mapper.readValue<MyClass>(emptyString).shouldBe(MyClass(""))
   }
 
   @Test

--- a/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderStringNullableDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderStringNullableDeserializerTest.kt
@@ -24,6 +24,12 @@ internal class PlaintextConfigLoaderStringNullableDeserializerTest : ConfigLoade
     }
   """.trimIndent()
 
+  private val emptyString: String = """
+    {
+      "message": ""
+    }
+  """.trimIndent()
+
   private val nullString = """
     {
       "message": null
@@ -48,6 +54,20 @@ internal class PlaintextConfigLoaderStringNullableDeserializerTest : ConfigLoade
     allowInsecureConfigSources(true)
     val mapper = createMapper()
     mapper.readValue<MyClass>(nonNullString).shouldBe(MyClass("Hello, World!"))
+  }
+
+  @Test
+  fun `empty (allowInsecureConfigSources = false)`(): Unit = runTest {
+    allowInsecureConfigSources(false)
+    val mapper = createMapper()
+    mapper.readValue<MyClass>(emptyString).shouldBe(MyClass(""))
+  }
+
+  @Test
+  fun `empty (allowInsecureConfigSources = true)`(): Unit = runTest {
+    allowInsecureConfigSources(true)
+    val mapper = createMapper()
+    mapper.readValue<MyClass>(emptyString).shouldBe(MyClass(""))
   }
 
   @Test


### PR DESCRIPTION
### Summary

Protected strings are not allowed to come from environment variables, since it's not secure. However, if the string is null or empty (as is often the case for tests), it is not considered inscure.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
