### PR TITLE
Add JSONB support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ jacksonDatatypeJdk8 = { module = "com.fasterxml.jackson.datatype:jackson-datatyp
 jacksonModuleKotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 javaxMoney = { module = "javax.money:money-api", version.ref = "javaxMoney" }
 jdbiCore = { module = "org.jdbi:jdbi3-core", version.ref = "jdbi" }
+jdbiJackson = { module = "org.jdbi:jdbi3-jackson2", version.ref = "jdbi" }
 jdbiKotlin = { module = "org.jdbi:jdbi3-kotlin", version.ref = "jdbi" }
 jdbiPostgres = { module = "org.jdbi:jdbi3-postgres", version.ref = "jdbi" }
 kotestRunner = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }

--- a/kairo-sql-feature/build.gradle.kts
+++ b/kairo-sql-feature/build.gradle.kts
@@ -9,12 +9,14 @@ dependencies {
   implementation(project(":kairo-logging"))
   implementation(project(":kairo-protected-string"))
   implementation(project(":kairo-reflect"))
+  implementation(project(":kairo-serialization"))
   implementation(project(":kairo-transaction-manager"))
   api(project(":kairo-updater"))  // Exposed for clients.
 
   implementation(libs.guava) // For [Resources.getResource].
   api(libs.hikari) // HikariDataSource is exposed.
   api(libs.jdbiCore)  // Exposed for clients.
+  api(libs.jdbiJackson) // There are some annotations to expose.
   api(libs.jdbiKotlin) // There are some extension functions to expose.
   implementation(libs.jdbiPostgres)
   api(libs.postgres) // Expose [ServerErrorMessage].

--- a/kairo-sql-feature/src/main/kotlin/kairo/sql/JdbiProvider.kt
+++ b/kairo-sql-feature/src/main/kotlin/kairo/sql/JdbiProvider.kt
@@ -4,6 +4,7 @@ import com.google.inject.Inject
 import com.google.inject.Singleton
 import com.zaxxer.hikari.HikariDataSource
 import kairo.dependencyInjection.LazySingletonProvider
+import kairo.sql.plugin.jackson.JacksonPlugin
 import kairo.sql.plugin.kairo.KairoPlugin
 import org.jdbi.v3.core.Jdbi
 import org.jdbi.v3.core.kotlin.KotlinPlugin
@@ -18,6 +19,7 @@ public class JdbiProvider @Inject constructor(
 ) : LazySingletonProvider<Jdbi>() {
   override fun create(): Jdbi =
     Jdbi.create(dataSource).apply {
+      installPlugin(JacksonPlugin())
       installPlugin(KairoPlugin())
       installPlugin(KotlinPlugin())
       installPlugin(PostgresPlugin())

--- a/kairo-sql-feature/src/main/kotlin/kairo/sql/plugin/jackson/JacksonPlugin.kt
+++ b/kairo-sql-feature/src/main/kotlin/kairo/sql/plugin/jackson/JacksonPlugin.kt
@@ -1,0 +1,19 @@
+package kairo.sql.plugin.jackson
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import kairo.serialization.jsonMapper
+import org.jdbi.v3.core.Handle
+import org.jdbi.v3.jackson2.Jackson2Config
+import org.jdbi.v3.jackson2.Jackson2Plugin
+
+internal class JacksonPlugin : Jackson2Plugin() {
+  private val mapper: JsonMapper =
+    jsonMapper {
+      allowUnknownProperties = true
+    }
+
+  override fun customizeHandle(handle: Handle): Handle =
+    super.customizeHandle(handle).apply {
+      getConfig(Jackson2Config::class.java).setMapper(mapper)
+    }
+}


### PR DESCRIPTION
### Summary

Database support for JSONB allows us to store binary JSON blobs in the Postgres database. Support for this leverages the existing serialization Feature.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
