### PR TITLE
Allow lateinit with JacksonXmlProperty annotation

### DIFF
--- a/.detekt/config.yaml
+++ b/.detekt/config.yaml
@@ -92,6 +92,7 @@ complexity:
     ignoreDefaultParameters: false
     ignoreDataClasses: true
     ignoreAnnotated:
+      - 'com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty'
       - 'com.google.inject.Inject'
   MethodOverloading:
     active: true


### PR DESCRIPTION
### Summary

XML serialization does not work properly with Kotlin data classes, so we recommend using `lateinit` instead.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
