### PR TITLE
Support Slack threads

### DIFF
--- a/kairo-slack-feature/src/main/kotlin/kairo/slack/NoopSlackClient.kt
+++ b/kairo-slack-feature/src/main/kotlin/kairo/slack/NoopSlackClient.kt
@@ -3,5 +3,10 @@ package kairo.slack
 import com.slack.api.model.block.LayoutBlock
 
 public class NoopSlackClient : SlackClient() {
-  override suspend fun sendMessage(channelName: String, message: List<LayoutBlock>): Unit = Unit
+  override suspend fun sendMessage(
+    channelName: String,
+    threadTs: String?,
+    message: List<LayoutBlock>,
+  ): Nothing? =
+    null
 }

--- a/kairo-slack-feature/src/main/kotlin/kairo/slack/SlackClient.kt
+++ b/kairo-slack-feature/src/main/kotlin/kairo/slack/SlackClient.kt
@@ -1,7 +1,12 @@
 package kairo.slack
 
+import com.slack.api.methods.response.chat.ChatPostMessageResponse
 import com.slack.api.model.block.LayoutBlock
 
 public abstract class SlackClient {
-  public abstract suspend fun sendMessage(channelName: String, message: List<LayoutBlock>)
+  public abstract suspend fun sendMessage(
+    channelName: String,
+    threadTs: String? = null,
+    message: List<LayoutBlock>,
+  ): ChatPostMessageResponse?
 }


### PR DESCRIPTION
### Summary

Adds support for sending messages to Slack threads instead of directly to channels.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
