### PR TITLE
Use Kotlin instead of bean-based serialization names

### DIFF
--- a/kairo-serialization/src/main/kotlin/kairo/serialization/ObjectMapperFactory.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/ObjectMapperFactory.kt
@@ -71,6 +71,7 @@ public abstract class ObjectMapperFactory<M : ObjectMapper, B : MapperBuilder<M,
       kotlinModule {
         this.configure(KotlinFeature.SingletonSupport, true)
         this.configure(KotlinFeature.StrictNullChecks, true)
+        this.configure(KotlinFeature.KotlinPropertyNameAsImplicitName, true)
       },
     )
   }

--- a/kairo-serialization/src/main/kotlin/kairo/serialization/module/increaseStrictness.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/module/increaseStrictness.kt
@@ -31,7 +31,7 @@ private fun MapperBuilder<*, *>.configureMapperFeatures() {
   configure(MapperFeature.ALLOW_VOID_VALUED_PROPERTIES, true)
   configure(MapperFeature.INFER_BUILDER_TYPE_BINDINGS, false)
   configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false)
-  configure(MapperFeature.USE_STD_BEAN_NAMING, true)
+  configure(MapperFeature.USE_STD_BEAN_NAMING, false)
   configure(MapperFeature.ALLOW_COERCION_OF_SCALARS, false)
   configure(MapperFeature.IGNORE_DUPLICATE_MODULE_REGISTRATIONS, false)
   configure(MapperFeature.IGNORE_MERGE_FOR_UNMERGEABLE, false)

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/format/JsonObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/format/JsonObjectMapperTest.kt
@@ -31,6 +31,7 @@ internal class JsonObjectMapperTest {
     val optionals: Optionals,
     val instant: Instant,
     val localDate: LocalDate,
+    val xAxis: String,
   ) {
     internal data class Booleans(
       val booleanTrue: Boolean,
@@ -96,6 +97,7 @@ internal class JsonObjectMapperTest {
       ),
       instant = Instant.parse("2023-11-13T19:44:32.123456789Z"),
       localDate = LocalDate.parse("2023-11-13"),
+      xAxis = "This property verifies standard bean naming isn't used.",
     )
 
   private val string: String = """
@@ -127,7 +129,8 @@ internal class JsonObjectMapperTest {
         "stringInt": "42",
         "stringTrue": "true"
       },
-      "uuid": "3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8"
+      "uuid": "3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8",
+      "xAxis": "This property verifies standard bean naming isn't used."
     }
   """.trimIndent()
 

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/format/XmlObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/format/XmlObjectMapperTest.kt
@@ -31,6 +31,7 @@ internal class XmlObjectMapperTest {
     val optionals: Optionals,
     val instant: Instant,
     val localDate: LocalDate,
+    val xAxis: String,
   ) {
     internal data class Booleans(
       val booleanTrue: Boolean,
@@ -96,6 +97,7 @@ internal class XmlObjectMapperTest {
       ),
       instant = Instant.parse("2023-11-13T19:44:32.123456789Z"),
       localDate = LocalDate.parse("2023-11-13"),
+      xAxis = "This property verifies standard bean naming isn't used.",
     )
 
   private val string: String = """
@@ -128,6 +130,7 @@ internal class XmlObjectMapperTest {
         <stringTrue>true</stringTrue>
       </strings>
       <uuid>3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8</uuid>
+      <xAxis>This property verifies standard bean naming isn't used.</xAxis>
     </MyClass>
   """.trimIndent() + '\n'
 

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/format/YamlObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/format/YamlObjectMapperTest.kt
@@ -31,6 +31,7 @@ internal class YamlObjectMapperTest {
     val optionals: Optionals,
     val instant: Instant,
     val localDate: LocalDate,
+    val xAxis: String,
   ) {
     internal data class Booleans(
       val booleanTrue: Boolean,
@@ -96,6 +97,7 @@ internal class YamlObjectMapperTest {
       ),
       instant = Instant.parse("2023-11-13T19:44:32.123456789Z"),
       localDate = LocalDate.parse("2023-11-13"),
+      xAxis = "This property verifies standard bean naming isn't used.",
     )
 
   private val string: String = """
@@ -122,6 +124,7 @@ internal class YamlObjectMapperTest {
       stringInt: "42"
       stringTrue: "true"
     uuid: "3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8"
+    xAxis: "This property verifies standard bean naming isn't used."
   """.trimIndent() + '\n'
 
   @Test


### PR DESCRIPTION
### Summary

See https://github.com/FasterXML/jackson-module-kotlin/issues/630.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
