### PR TITLE
Change updater interface

### DIFF
--- a/kairo-updater/src/main/kotlin/kairo/updater/Updater.kt
+++ b/kairo-updater/src/main/kotlin/kairo/updater/Updater.kt
@@ -2,8 +2,8 @@ package kairo.updater
 
 import java.util.Optional
 
-public fun interface Updater<T> {
-  public suspend fun update(model: T): T
+public fun interface Updater<T, U> {
+  public suspend fun update(model: T): U
 }
 
 /**


### PR DESCRIPTION
### Summary

Updaters should have access to the full model, not just the properties that can be updated.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
