### PR TITLE
Reuse SecretManagerServiceClient instance in DefaultGcpSecretSupplier

### DIFF
--- a/kairo-config/src/main/kotlin/kairo/config/ConfigLoader.kt
+++ b/kairo-config/src/main/kotlin/kairo/config/ConfigLoader.kt
@@ -134,7 +134,7 @@ public class ConfigLoader(
         ConfigLoaderConfig(
           commandRunner = DefaultCommandRunner,
           environmentVariableSupplier = DefaultEnvironmentVariableSupplier,
-          gcpSecretSupplier = DefaultGcpSecretSupplier,
+          gcpSecretSupplier = DefaultGcpSecretSupplier(),
         ),
       )
 

--- a/kairo-gcp-secret-supplier/src/main/kotlin/kairo/gcpSecretSupplier/DefaultGcpSecretSupplier.kt
+++ b/kairo-gcp-secret-supplier/src/main/kotlin/kairo/gcpSecretSupplier/DefaultGcpSecretSupplier.kt
@@ -9,13 +9,17 @@ import kairo.protectedString.ProtectedString
 
 private val logger: KLogger = KotlinLogging.logger {}
 
-public object DefaultGcpSecretSupplier : GcpSecretSupplier() {
+public class DefaultGcpSecretSupplier : GcpSecretSupplier() {
+  private val secretManagerServiceClient: SecretManagerServiceClient by lazy {
+    SecretManagerServiceClient.create()
+  }
+
   /**
    * Note: This approach is blocking; it does not leverage Kotlin coroutines.
    */
   override fun get(id: String): ProtectedString? {
     logger.debug { "Getting GCP secret: $id." }
-    return SecretManagerServiceClient.create().use { client ->
+    return secretManagerServiceClient.use { client ->
       val secretVersionName = SecretVersionName.parse(id)
       val accessResponse = try {
         client.accessSecretVersion(secretVersionName)


### PR DESCRIPTION
### Summary

During startup profiling I found we spend 600ms (on my computer) repeatedly creating this secrets manager client for each use. We should be able to hold a common instance in the supplier class.

### Checklist

- [ ] Documentation (root README, Feature READMEs, KDoc, comments).
- [ ] Logging.
- [ ] Tests.
