### PR TITLE
Make DeterministicKairoIdGenerator threadsafe

### DIFF
--- a/kairo-id-feature/src/main/kotlin/kairo/id/DeterministicKairoIdGenerator.kt
+++ b/kairo-id-feature/src/main/kotlin/kairo/id/DeterministicKairoIdGenerator.kt
@@ -1,6 +1,7 @@
 package kairo.id
 
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * This is a deterministic way of generating Kairo IDs that's useful for tests.
@@ -22,15 +23,14 @@ public class DeterministicKairoIdGenerator(
     }
   }
 
-  private var seed: Int = 0
+  private val seed: AtomicInteger = AtomicInteger(0)
 
   public fun reset() {
-    seed = 0
+    seed.set(0)
   }
 
   override fun generate(): KairoId {
-    val result = get(seed)
-    seed++
+    val result = get(seed.getAndIncrement())
     return result
   }
 

--- a/kairo-id-feature/src/main/kotlin/kairo/id/DeterministicKairoIdGenerator.kt
+++ b/kairo-id-feature/src/main/kotlin/kairo/id/DeterministicKairoIdGenerator.kt
@@ -29,10 +29,8 @@ public class DeterministicKairoIdGenerator(
     seed.set(0)
   }
 
-  override fun generate(): KairoId {
-    val result = get(seed.getAndIncrement())
-    return result
-  }
+  override fun generate(): KairoId =
+    get(seed.getAndIncrement())
 
   public operator fun get(id: Int): KairoId =
     generate(prefix, id)

--- a/kairo-uuid-feature/src/main/kotlin/kairo/uuid/DeterministicKairoUuidGenerator.kt
+++ b/kairo-uuid-feature/src/main/kotlin/kairo/uuid/DeterministicKairoUuidGenerator.kt
@@ -1,5 +1,6 @@
 package kairo.uuid
 
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.uuid.Uuid
 
 /**
@@ -9,17 +10,14 @@ import kotlin.uuid.Uuid
  * Although UUID strings are base-16, [DeterministicKairoUuidGenerator] only uses numbers.
  */
 public class DeterministicKairoUuidGenerator : KairoUuidGenerator() {
-  private var seed: Int = 0
+  private val seed: AtomicInteger = AtomicInteger(0)
 
   public fun reset() {
-    seed = 0
+    seed.set(0)
   }
 
-  override fun generate(): Uuid {
-    val result = get(seed)
-    seed++
-    return result
-  }
+  override fun generate(): Uuid =
+    get(seed.getAndIncrement())
 
   public operator fun get(id: Int): Uuid =
     generate(id)


### PR DESCRIPTION
While working on the old Highbeam version of this I noticed that
the incrementing ID seed is not thread safe. This changes it to
use an atomic integer instead, which seems to do the right thing.

### Summary

Placeholder.

### Checklist

- [ ] Documentation (root README, Feature READMEs, KDoc, comments).
- [ ] Logging.
- [ ] Tests.
