### PR TITLE
Add ensureTransaction wrapper in TransactionManager

### DIFF
--- a/kairo-transaction-manager/src/main/kotlin/kairo/transactionManager/EnsureTransaction.kt
+++ b/kairo-transaction-manager/src/main/kotlin/kairo/transactionManager/EnsureTransaction.kt
@@ -1,0 +1,17 @@
+package kairo.transactionManager
+
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val logger: KLogger = KotlinLogging.logger {}
+
+/**
+ * Extension function that checks for transaction context before executing a suspending function.
+ */
+public suspend fun <T> ensureTransaction(block: () -> T): T {
+  getTransactionContext() ?: run {
+    logger.error { "Transaction context is missing" }
+    throw MissingTransactionException()
+  }
+  return block()
+}

--- a/kairo-transaction-manager/src/main/kotlin/kairo/transactionManager/EnsureTransaction.kt
+++ b/kairo-transaction-manager/src/main/kotlin/kairo/transactionManager/EnsureTransaction.kt
@@ -8,7 +8,7 @@ private val logger: KLogger = KotlinLogging.logger {}
 /**
  * Extension function that checks for transaction context before executing a suspending function.
  */
-public suspend fun <T> ensureTransaction(block: () -> T): T {
+public suspend fun <T> ensureTransaction(block: suspend () -> T): T {
   getTransactionContext() ?: run {
     logger.error { "Transaction context is missing" }
     throw MissingTransactionException()

--- a/kairo-transaction-manager/src/main/kotlin/kairo/transactionManager/MissingTransactionException.kt
+++ b/kairo-transaction-manager/src/main/kotlin/kairo/transactionManager/MissingTransactionException.kt
@@ -1,0 +1,9 @@
+package kairo.transactionManager
+
+/**
+ * Exception thrown when a method requiring a transaction is called without one.
+ */
+public class MissingTransactionException : TransactionManagerException(
+  message = "This operation requires an active transaction context",
+  cause = Exception("No transaction context was found"),
+)

--- a/kairo-transaction-manager/src/test/kotlin/kairo/transactionManager/TransactionManagerTest.kt
+++ b/kairo-transaction-manager/src/test/kotlin/kairo/transactionManager/TransactionManagerTest.kt
@@ -400,4 +400,34 @@ internal class TransactionManagerTest {
       "Type0 close context",
     )
   }
+
+  @Test
+  fun `ensure transaction, no transaction context`(): Unit = runTest {
+    shouldThrow<MissingTransactionException> {
+      ensureTransaction {
+        events.add("Operation 0")
+      }
+    }
+    events.shouldBeEmpty()
+  }
+
+  @Test
+  fun `ensure transaction, transaction context`(): Unit = runTest {
+    transactionManager.transaction(key<Type0>(), key<Type1>()) {
+      ensureTransaction {
+        events.add("Operation 0")
+      }
+    }
+    events.shouldContainExactly(
+      "Type0 create context",
+      "Type1 create context",
+      "Type0 begin transaction",
+      "Type1 begin transaction",
+      "Operation 0",
+      "Type1 commit transaction",
+      "Type0 commit transaction",
+      "Type1 close context",
+      "Type0 close context",
+    )
+  }
 }


### PR DESCRIPTION
### Summary

When using chunkedFlow with Sql feature, the ResultSet is closed before we call the `collect` function on the `Flow`. Having an `ensuredTransaction` will check whether the function is called in a Transaction.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
