### PR TITLE
Support additional Flyway properties

### DIFF
--- a/kairo-sql-migration-feature/src/main/kotlin/kairo/sqlMigration/FlywayProvider.kt
+++ b/kairo-sql-migration-feature/src/main/kotlin/kairo/sqlMigration/FlywayProvider.kt
@@ -27,6 +27,7 @@ internal class FlywayProvider(
   @Suppress("SpreadOperator") // The spread operator causes a full array copy, which is fine at startup time.
   override fun create(): Flyway =
     Flyway.configure()
+      .configuration(config.additionalProperties)
       .cleanOnValidationError(config.cleanOnValidationError)
       .cleanDisabled(DefaultEnvironmentVariableSupplier["KAIRO_CLEAN_DATABASE"] != true.toString())
       .locations(*config.locations.toTypedArray())

--- a/kairo-sql-migration-feature/src/main/kotlin/kairo/sqlMigration/KairoSqlMigrationConfig.kt
+++ b/kairo-sql-migration-feature/src/main/kotlin/kairo/sqlMigration/KairoSqlMigrationConfig.kt
@@ -1,6 +1,7 @@
 package kairo.sqlMigration
 
 public data class KairoSqlMigrationConfig(
+  val additionalProperties: Map<String, String>,
   val name: String,
   val run: Boolean,
   val cleanOnValidationError: Boolean,


### PR DESCRIPTION
This will allow setting miscellaneous Flyway configs not explicitly
supported by Kairo otherwise. I particularly want this so I can set
`flyway.postgresql.transactional.lock = false` in order to support
concurrent index creation with Postgres.

See: https://github.com/flyway/flyway/issues/3508

I haven't tested this, but I think it should work?
