### PR TITLE
Upgrade Flyway to 11.5.0 (major version)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 auth0JavaJwt = "4.5.0" # https://github.com/auth0/java-jwt/releases
 auth0JwksRsa = "0.22.1" # https://github.com/auth0/jwks-rsa-java/releases
-flyway = "10.22.0" # https://github.com/flyway/flyway/releases
+flyway = "11.5.0" # https://github.com/flyway/flyway/releases
 gcpCloudScheduler = "2.59.0" # https://mvnrepository.com/artifact/com.google.cloud/google-cloud-scheduler
 gcpCloudTasks = "2.59.0" # https://mvnrepository.com/artifact/com.google.cloud/google-cloud-tasks
 gcpSecretManager = "2.59.0" # https://mvnrepository.com/artifact/com.google.cloud/google-cloud-secretmanager


### PR DESCRIPTION
### Summary

The release notes for 11.0.0 read
> `cleanOnValidationError` function and configuration has been removed. An error will be thrown if this feature is configured

Kairo uses `cleanOnValidationError`. However, it seems this is referring to something else? Because it still works.

### Checklist

- [x] Documentation (root README, Feature READMEs, KDoc, comments).
- [x] Logging.
- [x] Tests.
