### PR TITLE
Change `Auth.all` from using a lambda to list

### DIFF
--- a/kairo-rest-feature/src/main/kotlin/kairo/rest/auth/Auth.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/rest/auth/Auth.kt
@@ -34,11 +34,11 @@ public class Auth(
 }
 
 /**
- * Requires that all the provided [Auth] instances are successful.
+ * Returns the first non-successful auth result, or success.
  */
 @Suppress("UnusedReceiverParameter")
-public suspend fun AuthProvider.all(block: suspend MutableList<Auth.Result>.() -> Unit): Auth.Result {
-  buildList { block() }.forEach { auth ->
+public fun AuthProvider.all(authResults: List<Auth.Result>): Auth.Result {
+  authResults.forEach { auth ->
     if (auth != Auth.Result.Success) return@all auth
   }
   return Auth.Result.Success


### PR DESCRIPTION
The lambda approach provides dangerous footgun, since if the user
forgets to add an auth result to the list it will implicitly not run.
The syntactic sugar is not worth the auth risk.
