### PR TITLE
Upgrade Jackson to 2.19.0

### DIFF
--- a/.detekt/config.yaml
+++ b/.detekt/config.yaml
@@ -657,7 +657,6 @@ style:
       - 'com.sun.security.*'
       - 'com.sun.tools.javac.comp.Flow'
       - 'com.typesafe.config.Optional' # Use the JDK version instead.
-      - 'io.github.projectmapk.jackson.module.kogera.jsonMapper'
       - 'io.grpc.netty.*'
       - 'io.kotest.core.spec.*' # Use JUnit test annotations.
       - 'io.ktor.client.HttpClient' # Use kairo.client.KairoClient.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Kairo is an application framework built for Kotlin.
 - Java 21
 - Ktor 3.0
 - Guice 7.0
-- Jackson 2.18
+- Jackson 2.19
 
 ### Style guide
 

--- a/buildSrc/src/main/kotlin/kairo.gradle.kts
+++ b/buildSrc/src/main/kotlin/kairo.gradle.kts
@@ -9,9 +9,6 @@ repositories {
   mavenLocal()
   mavenCentral()
   maven {
-    url = uri("https://jitpack.io")
-  }
-  maven {
     url = uri("artifactregistry://us-central1-maven.pkg.dev/airborne-software/maven")
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,8 +9,7 @@ googleApiCommon = "2.47.0" # // https://mvnrepository.com/artifact/com.google.ap
 guava = "33.4.8-jre" # https://github.com/google/guava/releases
 guice = "7.0.0" # https://github.com/google/guice/releases
 hikari = "6.3.0" # https://github.com/brettwooldridge/HikariCP/tags
-jackson = "2.18.3" # https://github.com/FasterXML/jackson-core/tags
-jacksonModuleKogera = "2.18.3-beta18" # https://github.com/ProjectMapK/jackson-module-kogera/releases # TODO: Remove when 2.19 comes out.
+jackson = "2.19.0" # https://github.com/FasterXML/jackson-core/tags
 javaxMoney = "1.1" # https://mvnrepository.com/artifact/javax.money/money-api
 jdbi = "3.49.0" # https://github.com/jdbi/jdbi/releases
 kotest = "5.9.1" # https://github.com/kotest/kotest/releases
@@ -39,7 +38,7 @@ jacksonCore = { module = "com.fasterxml.jackson.core:jackson-core", version.ref 
 jacksonDataformatXml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml", version.ref = "jackson" }
 jacksonDataformatYaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
 jacksonDatatypeJdk8 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jdk8", version.ref = "jackson" }
-jacksonModuleKogera = { module = "com.github.ProjectMapK:jackson-module-kogera", version.ref = "jacksonModuleKogera" }
+jacksonModuleKotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 javaxMoney = { module = "javax.money:money-api", version.ref = "javaxMoney" }
 jdbiCore = { module = "org.jdbi:jdbi3-core", version.ref = "jdbi" }
 jdbiJackson = { module = "org.jdbi:jdbi3-jackson2", version.ref = "jdbi" }

--- a/kairo-alternative-money-formatters/src/main/kotlin/kairo/alternativeMoneyFormatters/AmbiguousStringMoneyFormatter.kt
+++ b/kairo-alternative-money-formatters/src/main/kotlin/kairo/alternativeMoneyFormatters/AmbiguousStringMoneyFormatter.kt
@@ -36,9 +36,9 @@ public class AmbiguousStringMoneyFormatter(
 
   private fun formatForCurrency(currency: CurrencyUnit): NumberFormat =
     NumberFormat.getCurrencyInstance(Locale.US).apply {
-      maximumFractionDigits = Int.MAX_VALUE
-      minimumFractionDigits = currency.defaultFractionDigits
+      this.maximumFractionDigits = Int.MAX_VALUE
+      this.minimumFractionDigits = currency.defaultFractionDigits
       this.currency = Currency.getInstance(currency.currencyCode)
-      roundingMode = RoundingMode.UNNECESSARY
+      this.roundingMode = RoundingMode.UNNECESSARY
     }
 }

--- a/kairo-alternative-money-formatters/src/test/kotlin/kairo/alternativeMoneyFormatters/AmbiguousStringMoneyFormatterCurrencyTest.kt
+++ b/kairo-alternative-money-formatters/src/test/kotlin/kairo/alternativeMoneyFormatters/AmbiguousStringMoneyFormatterCurrencyTest.kt
@@ -1,7 +1,7 @@
 package kairo.alternativeMoneyFormatters
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.convertValue
+import com.fasterxml.jackson.module.kotlin.convertValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import java.text.ParseException

--- a/kairo-alternative-money-formatters/src/test/kotlin/kairo/alternativeMoneyFormatters/AmountAsStringMoneyFormatterCurrencyTest.kt
+++ b/kairo-alternative-money-formatters/src/test/kotlin/kairo/alternativeMoneyFormatters/AmountAsStringMoneyFormatterCurrencyTest.kt
@@ -1,7 +1,7 @@
 package kairo.alternativeMoneyFormatters
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.convertValue
+import com.fasterxml.jackson.module.kotlin.convertValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper

--- a/kairo-alternative-money-formatters/src/test/kotlin/kairo/alternativeMoneyFormatters/CentsMoneyFormatterCurrencyTest.kt
+++ b/kairo-alternative-money-formatters/src/test/kotlin/kairo/alternativeMoneyFormatters/CentsMoneyFormatterCurrencyTest.kt
@@ -1,7 +1,7 @@
 package kairo.alternativeMoneyFormatters
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.convertValue
+import com.fasterxml.jackson.module.kotlin.convertValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper

--- a/kairo-config/src/main/kotlin/kairo/config/ConfigLoader.kt
+++ b/kairo-config/src/main/kotlin/kairo/config/ConfigLoader.kt
@@ -5,11 +5,11 @@ import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.databind.node.ValueNode
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import com.fasterxml.jackson.module.kotlin.convertValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.google.common.io.Resources
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.github.projectmapk.jackson.module.kogera.convertValue
-import io.github.projectmapk.jackson.module.kogera.readValue
 import kairo.commandRunner.DefaultCommandRunner
 import kairo.commandRunner.NoopCommandRunner
 import kairo.environmentVariableSupplier.DefaultEnvironmentVariableSupplier
@@ -103,7 +103,7 @@ public class ConfigLoader(
   }
 
   private fun merge(extends: ObjectNode, config: ObjectNode) {
-    config.fields().forEach { (name, jsonNode) ->
+    config.properties().forEach { (name, jsonNode) ->
       when (jsonNode) {
         is ArrayNode, is ValueNode -> mergeValueNode(extends, name, jsonNode)
         is ObjectNode -> mergeObjectNode(extends, name, jsonNode)

--- a/kairo-config/src/test/kotlin/kairo/config/CommandConfigLoaderBooleanDefaultDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/CommandConfigLoaderBooleanDefaultDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest

--- a/kairo-config/src/test/kotlin/kairo/config/CommandConfigLoaderBooleanNullableDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/CommandConfigLoaderBooleanNullableDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest

--- a/kairo-config/src/test/kotlin/kairo/config/CommandConfigLoaderIntDefaultDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/CommandConfigLoaderIntDefaultDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest

--- a/kairo-config/src/test/kotlin/kairo/config/CommandConfigLoaderIntNullableDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/CommandConfigLoaderIntNullableDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest

--- a/kairo-config/src/test/kotlin/kairo/config/CommandConfigLoaderProtectedStringDefaultDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/CommandConfigLoaderProtectedStringDefaultDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kairo.protectedString.ProtectedString

--- a/kairo-config/src/test/kotlin/kairo/config/CommandConfigLoaderProtectedStringNullableDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/CommandConfigLoaderProtectedStringNullableDeserializerTest.kt
@@ -1,6 +1,6 @@
 package kairo.config
 
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.protectedString.ProtectedString
 import kotlinx.coroutines.test.runTest

--- a/kairo-config/src/test/kotlin/kairo/config/CommandConfigLoaderStringDefaultDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/CommandConfigLoaderStringDefaultDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest

--- a/kairo-config/src/test/kotlin/kairo/config/CommandConfigLoaderStringNullableDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/CommandConfigLoaderStringNullableDeserializerTest.kt
@@ -1,6 +1,6 @@
 package kairo.config
 
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test

--- a/kairo-config/src/test/kotlin/kairo/config/EnvironmentVariableConfigLoaderBooleanDefaultDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/EnvironmentVariableConfigLoaderBooleanDefaultDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.every

--- a/kairo-config/src/test/kotlin/kairo/config/EnvironmentVariableConfigLoaderBooleanNullableDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/EnvironmentVariableConfigLoaderBooleanNullableDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.every

--- a/kairo-config/src/test/kotlin/kairo/config/EnvironmentVariableConfigLoaderIntDefaultDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/EnvironmentVariableConfigLoaderIntDefaultDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.every

--- a/kairo-config/src/test/kotlin/kairo/config/EnvironmentVariableConfigLoaderIntNullableDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/EnvironmentVariableConfigLoaderIntNullableDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.every

--- a/kairo-config/src/test/kotlin/kairo/config/EnvironmentVariableConfigLoaderProtectedStringDefaultDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/EnvironmentVariableConfigLoaderProtectedStringDefaultDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.every

--- a/kairo-config/src/test/kotlin/kairo/config/EnvironmentVariableConfigLoaderProtectedStringNullableDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/EnvironmentVariableConfigLoaderProtectedStringNullableDeserializerTest.kt
@@ -1,6 +1,6 @@
 package kairo.config
 
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import kairo.protectedString.ProtectedString

--- a/kairo-config/src/test/kotlin/kairo/config/EnvironmentVariableConfigLoaderStringDefaultDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/EnvironmentVariableConfigLoaderStringDefaultDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.every

--- a/kairo-config/src/test/kotlin/kairo/config/EnvironmentVariableConfigLoaderStringNullableDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/EnvironmentVariableConfigLoaderStringNullableDeserializerTest.kt
@@ -1,6 +1,6 @@
 package kairo.config
 
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import kotlinx.coroutines.test.runTest

--- a/kairo-config/src/test/kotlin/kairo/config/GcpSecretConfigLoaderBooleanDefaultDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/GcpSecretConfigLoaderBooleanDefaultDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.mockk.every
 import kairo.protectedString.ProtectedString

--- a/kairo-config/src/test/kotlin/kairo/config/GcpSecretConfigLoaderBooleanNullableDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/GcpSecretConfigLoaderBooleanNullableDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.every

--- a/kairo-config/src/test/kotlin/kairo/config/GcpSecretConfigLoaderIntDefaultDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/GcpSecretConfigLoaderIntDefaultDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.mockk.every
 import kairo.protectedString.ProtectedString

--- a/kairo-config/src/test/kotlin/kairo/config/GcpSecretConfigLoaderIntNullableDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/GcpSecretConfigLoaderIntNullableDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.every

--- a/kairo-config/src/test/kotlin/kairo/config/GcpSecretConfigLoaderProtectedStringDefaultDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/GcpSecretConfigLoaderProtectedStringDefaultDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.every

--- a/kairo-config/src/test/kotlin/kairo/config/GcpSecretConfigLoaderProtectedStringNullableDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/GcpSecretConfigLoaderProtectedStringNullableDeserializerTest.kt
@@ -1,6 +1,6 @@
 package kairo.config
 
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import kairo.protectedString.ProtectedString

--- a/kairo-config/src/test/kotlin/kairo/config/GcpSecretConfigLoaderStringDefaultDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/GcpSecretConfigLoaderStringDefaultDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.every

--- a/kairo-config/src/test/kotlin/kairo/config/GcpSecretConfigLoaderStringNullableDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/GcpSecretConfigLoaderStringNullableDeserializerTest.kt
@@ -1,6 +1,6 @@
 package kairo.config
 
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import kairo.protectedString.ProtectedString

--- a/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderBooleanDefaultDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderBooleanDefaultDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest

--- a/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderBooleanNullableDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderBooleanNullableDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest

--- a/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderIntDefaultDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderIntDefaultDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest

--- a/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderIntNullableDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderIntNullableDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest

--- a/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderProtectedStringDefaultDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderProtectedStringDefaultDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kairo.protectedString.ProtectedString

--- a/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderProtectedStringNullableDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderProtectedStringNullableDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kairo.protectedString.ProtectedString

--- a/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderStringDefaultDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderStringDefaultDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest

--- a/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderStringNullableDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/PlaintextConfigLoaderStringNullableDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest

--- a/kairo-config/src/test/kotlin/kairo/config/UnsupportedSourceConfigLoaderProtectedStringDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/UnsupportedSourceConfigLoaderProtectedStringDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import kairo.protectedString.ProtectedString
 import kotlinx.coroutines.test.runTest

--- a/kairo-config/src/test/kotlin/kairo/config/UnsupportedSourceConfigLoaderStringDeserializerTest.kt
+++ b/kairo-config/src/test/kotlin/kairo/config/UnsupportedSourceConfigLoaderStringDeserializerTest.kt
@@ -1,7 +1,7 @@
 package kairo.config
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test

--- a/kairo-date-range/src/test/kotlin/kairo/dateRange/InstantRangeSerializationTest.kt
+++ b/kairo-date-range/src/test/kotlin/kairo/dateRange/InstantRangeSerializationTest.kt
@@ -2,7 +2,7 @@ package kairo.dateRange
 
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import java.time.Instant

--- a/kairo-date-range/src/test/kotlin/kairo/dateRange/LocalDateRangeSerializationTest.kt
+++ b/kairo-date-range/src/test/kotlin/kairo/dateRange/LocalDateRangeSerializationTest.kt
@@ -2,7 +2,7 @@ package kairo.dateRange
 
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import java.time.LocalDate

--- a/kairo-date-range/src/test/kotlin/kairo/dateRange/YearMonthRangeSerializationTest.kt
+++ b/kairo-date-range/src/test/kotlin/kairo/dateRange/YearMonthRangeSerializationTest.kt
@@ -2,7 +2,7 @@ package kairo.dateRange
 
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import java.time.YearMonth

--- a/kairo-do-not-log-string/src/test/kotlin/kairo/doNotLogString/DoNotLogStringSerializationTest.kt
+++ b/kairo-do-not-log-string/src/test/kotlin/kairo/doNotLogString/DoNotLogStringSerializationTest.kt
@@ -1,7 +1,7 @@
 package kairo.doNotLogString
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.util.kairoWrite

--- a/kairo-google-cloud-scheduler-feature/src/main/kotlin/kairo/googleCloudScheduler/RealGoogleCloudScheduler.kt
+++ b/kairo-google-cloud-scheduler-feature/src/main/kotlin/kairo/googleCloudScheduler/RealGoogleCloudScheduler.kt
@@ -19,7 +19,7 @@ public abstract class RealGoogleCloudScheduler(
   final override suspend fun create(job: Job, config: Config) {
     logger.info { "Creating job: $job (config: $config)." }
     val request = CreateJobRequest.newBuilder().apply {
-      parent = buildLocationName().toString()
+      this.parent = buildLocationName().toString()
       this.job = buildJob(job.details, config)
     }.build()
     cloudSchedulerClient.createJobCallable().futureCall(request).await()

--- a/kairo-google-cloud-tasks-feature/src/main/kotlin/kairo/googleCloudTasks/RealGoogleCloudTasks.kt
+++ b/kairo-google-cloud-tasks-feature/src/main/kotlin/kairo/googleCloudTasks/RealGoogleCloudTasks.kt
@@ -20,7 +20,7 @@ public abstract class RealGoogleCloudTasks(
     val task = task(endpoint)
     logger.info { "Creating task: $task." }
     val request = CreateTaskRequest.newBuilder().apply {
-      parent = buildQueueName(task.queueName).toString()
+      this.parent = buildQueueName(task.queueName).toString()
       this.task = buildTask(task.details)
     }.build()
     cloudTasksClient.createTaskCallable().futureCall(request).await()

--- a/kairo-id-feature/src/test/kotlin/kairo/id/KairoIdSerializationTest.kt
+++ b/kairo-id-feature/src/test/kotlin/kairo/id/KairoIdSerializationTest.kt
@@ -1,7 +1,7 @@
 package kairo.id
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.util.kairoWrite

--- a/kairo-protected-string/src/test/kotlin/kairo/protectedString/ProtectedStringSerializationTest.kt
+++ b/kairo-protected-string/src/test/kotlin/kairo/protectedString/ProtectedStringSerializationTest.kt
@@ -1,7 +1,7 @@
 package kairo.protectedString
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.util.kairoWrite

--- a/kairo-rest-feature/src/main/kotlin/kairo/rest/auth/JwtPrincipal.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/rest/auth/JwtPrincipal.kt
@@ -3,7 +3,7 @@ package kairo.rest.auth
 import com.auth0.jwt.interfaces.DecodedJWT
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.jacksonTypeRef
+import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 import kairo.serialization.jsonMapper
 import kairo.serialization.property.allowUnknownProperties
 

--- a/kairo-rest-feature/src/main/kotlin/kairo/rest/exception/JsonBadRequestException.kt
+++ b/kairo-rest-feature/src/main/kotlin/kairo/rest/exception/JsonBadRequestException.kt
@@ -41,8 +41,8 @@ public abstract class JsonBadRequestException(
         return path.joinToString("") { reference ->
           buildString {
             when {
-              reference.isNamed() -> this.append(".${reference.fieldName}")
-              reference.isNumbered() -> this.append("[${reference.index}]")
+              reference.isNamed() -> append(".${reference.fieldName}")
+              reference.isNumbered() -> append("[${reference.index}]")
               else -> error("Unsupported reference: $reference.")
             }
           }

--- a/kairo-rest-feature/src/test/kotlin/kairo/rest/exceptionHandler/ExceptionHandlerTest.kt
+++ b/kairo-rest-feature/src/test/kotlin/kairo/rest/exceptionHandler/ExceptionHandlerTest.kt
@@ -1,6 +1,6 @@
 package kairo.rest.exceptionHandler
 
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.HttpRequestBuilder

--- a/kairo-serialization/build.gradle.kts
+++ b/kairo-serialization/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
   api(libs.jacksonDataformatXml)
   api(libs.jacksonDataformatYaml)
   implementation(libs.jacksonDatatypeJdk8)
-  api(libs.jacksonModuleKogera) // There are some extension functions to expose.
+  api(libs.jacksonModuleKotlin) // There are some extension functions to expose.
   implementation(libs.ktorHttpJvm)
 
   testImplementation(project(":kairo-logging:testing"))

--- a/kairo-serialization/src/main/kotlin/kairo/serialization/ObjectMapperFactory.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/ObjectMapperFactory.kt
@@ -71,8 +71,8 @@ public abstract class ObjectMapperFactory<M : ObjectMapper, B : MapperBuilder<M,
     builder.addModule(
       kotlinModule {
         configure(KotlinFeature.SingletonSupport, true)
-        configure(KotlinFeature.NewStrictNullChecks, true)
         configure(KotlinFeature.KotlinPropertyNameAsImplicitName, true)
+        configure(KotlinFeature.NewStrictNullChecks, true)
       },
     )
   }

--- a/kairo-serialization/src/main/kotlin/kairo/serialization/ObjectMapperFactory.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/ObjectMapperFactory.kt
@@ -7,10 +7,10 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.cfg.JsonNodeFeature
 import com.fasterxml.jackson.databind.cfg.MapperBuilder
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
+import com.fasterxml.jackson.module.kotlin.KotlinFeature
+import com.fasterxml.jackson.module.kotlin.kotlinModule
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.github.projectmapk.jackson.module.kogera.KotlinFeature
-import io.github.projectmapk.jackson.module.kogera.kotlinModule
 import java.util.Optional
 import kairo.serialization.module.increaseStrictness
 import kairo.serialization.module.ktor.KtorModule
@@ -58,7 +58,7 @@ public abstract class ObjectMapperFactory<M : ObjectMapper, B : MapperBuilder<M,
   private fun configureJava(builder: B) {
     builder.addModule(
       Jdk8Module().apply {
-        this.configureReadAbsentAsNull(true)
+        configureReadAbsentAsNull(true)
       },
     )
   }
@@ -70,8 +70,9 @@ public abstract class ObjectMapperFactory<M : ObjectMapper, B : MapperBuilder<M,
   private fun configureKotlin(builder: B) {
     builder.addModule(
       kotlinModule {
-        this.configure(KotlinFeature.SingletonSupport, true)
-        this.configure(KotlinFeature.StrictNullChecks, true)
+        configure(KotlinFeature.SingletonSupport, true)
+        configure(KotlinFeature.NewStrictNullChecks, true)
+        configure(KotlinFeature.KotlinPropertyNameAsImplicitName, true)
       },
     )
   }
@@ -97,18 +98,18 @@ public abstract class ObjectMapperFactory<M : ObjectMapper, B : MapperBuilder<M,
    * See the corresponding test for more spec.
    */
   protected open fun configurePrettyPrinting(builder: B) {
-    builder.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, this.prettyPrint)
+    builder.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, prettyPrint)
     builder.configure(MapperFeature.SORT_CREATOR_PROPERTIES_FIRST, false)
 
-    builder.configure(SerializationFeature.INDENT_OUTPUT, this.prettyPrint)
-    builder.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, this.prettyPrint)
+    builder.configure(SerializationFeature.INDENT_OUTPUT, prettyPrint)
+    builder.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, prettyPrint)
 
-    builder.configure(JsonNodeFeature.WRITE_PROPERTIES_SORTED, this.prettyPrint)
+    builder.configure(JsonNodeFeature.WRITE_PROPERTIES_SORTED, prettyPrint)
   }
 
   private fun setUnknownPropertyHandling(builder: B) {
-    builder.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, !this.allowUnknownProperties)
-    builder.configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, !this.allowUnknownProperties)
-    builder.configure(DeserializationFeature.FAIL_ON_UNEXPECTED_VIEW_PROPERTIES, !this.allowUnknownProperties)
+    builder.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, !allowUnknownProperties)
+    builder.configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, !allowUnknownProperties)
+    builder.configure(DeserializationFeature.FAIL_ON_UNEXPECTED_VIEW_PROPERTIES, !allowUnknownProperties)
   }
 }

--- a/kairo-serialization/src/main/kotlin/kairo/serialization/module/increaseStrictness.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/module/increaseStrictness.kt
@@ -31,11 +31,13 @@ private fun MapperBuilder<*, *>.configureMapperFeatures() {
   configure(MapperFeature.ALLOW_VOID_VALUED_PROPERTIES, true)
   configure(MapperFeature.INFER_BUILDER_TYPE_BINDINGS, false)
   configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false)
-  configure(MapperFeature.USE_STD_BEAN_NAMING, false)
+  configure(MapperFeature.USE_STD_BEAN_NAMING, true)
   configure(MapperFeature.ALLOW_COERCION_OF_SCALARS, false)
   configure(MapperFeature.IGNORE_DUPLICATE_MODULE_REGISTRATIONS, false)
   configure(MapperFeature.IGNORE_MERGE_FOR_UNMERGEABLE, false)
   configure(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES, true)
+  configure(MapperFeature.REQUIRE_HANDLERS_FOR_JAVA8_OPTIONALS, true)
+  configure(MapperFeature.REQUIRE_HANDLERS_FOR_JAVA8_TIMES, true)
 }
 
 private fun MapperBuilder<*, *>.configureSerializationFeatures() {
@@ -49,6 +51,7 @@ private fun MapperBuilder<*, *>.configureDeserializationFeatures() {
   configure(DeserializationFeature.FAIL_ON_NUMBERS_FOR_ENUMS, true)
   configure(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY, true)
   configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, true)
+  configure(DeserializationFeature.FAIL_ON_SUBTYPE_CLASS_NOT_REGISTERED, false)
   configure(DeserializationFeature.ACCEPT_FLOAT_AS_INT, false)
 }
 

--- a/kairo-serialization/src/main/kotlin/kairo/serialization/module/increaseStrictness.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/module/increaseStrictness.kt
@@ -51,7 +51,7 @@ private fun MapperBuilder<*, *>.configureDeserializationFeatures() {
   configure(DeserializationFeature.FAIL_ON_NUMBERS_FOR_ENUMS, true)
   configure(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY, true)
   configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, true)
-  configure(DeserializationFeature.FAIL_ON_SUBTYPE_CLASS_NOT_REGISTERED, false)
+  configure(DeserializationFeature.FAIL_ON_SUBTYPE_CLASS_NOT_REGISTERED, true)
   configure(DeserializationFeature.ACCEPT_FLOAT_AS_INT, false)
 }
 

--- a/kairo-serialization/src/main/kotlin/kairo/serialization/util/ObjectMapper.kt
+++ b/kairo-serialization/src/main/kotlin/kairo/serialization/util/ObjectMapper.kt
@@ -4,7 +4,7 @@ package kairo.serialization.util
 
 import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.github.projectmapk.jackson.module.kogera.convertValue
+import com.fasterxml.jackson.module.kotlin.convertValue
 import kairo.reflect.kairoType
 import kairo.serialization.typeReference
 

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/format/JsonObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/format/JsonObjectMapperTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.Instant
 import java.time.LocalDate

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/format/XmlObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/format/XmlObjectMapperTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.Instant
 import java.time.LocalDate

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/format/YamlObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/format/YamlObjectMapperTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.Instant
 import java.time.LocalDate

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/PolymorphismObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/PolymorphismObjectMapperTest.kt
@@ -3,7 +3,7 @@ package kairo.serialization.module
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.util.kairoWrite

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/UnknownPropertyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/UnknownPropertyObjectMapperTest.kt
@@ -1,6 +1,6 @@
 package kairo.serialization.module
 
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.property.allowUnknownProperties

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/java/OptionalDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/java/OptionalDefaultObjectMapperTest.kt
@@ -2,7 +2,7 @@ package kairo.serialization.module.java
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.util.Optional
 import kairo.serialization.jsonMapper

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/java/OptionalNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/java/OptionalNullableObjectMapperTest.kt
@@ -2,7 +2,7 @@ package kairo.serialization.module.java
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.util.Optional
 import kairo.serialization.jsonMapper

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/jvm/OptionalNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/jvm/OptionalNullableObjectMapperTest.kt
@@ -1,4 +1,4 @@
-package kairo.serialization.module.java
+package kairo.serialization.module.jvm
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.json.JsonMapper
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.util.Optional
 import kairo.serialization.jsonMapper
-import kairo.serialization.serializationShouldFail
 import kairo.serialization.util.kairoWrite
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
@@ -20,13 +19,13 @@ import org.junit.jupiter.api.Test
  * since null is serialized to missing and Optional.empty() is serialized to null.
  * However, this approach is in fact necessary to provide consistency between nullable and non-nullable Optionals.
  */
-internal class OptionalDefaultObjectMapperTest {
+internal class OptionalNullableObjectMapperTest {
   /**
-   * This test is specifically for non-nullable properties.
+   * This test is specifically for nullable properties.
    */
-  @JsonInclude(JsonInclude.Include.NON_NULL)
   internal data class MyClass(
-    val value: Optional<Int>,
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val value: Optional<Int>?,
   )
 
   private val mapper: JsonMapper = jsonMapper().build()
@@ -42,6 +41,11 @@ internal class OptionalDefaultObjectMapperTest {
   }
 
   @Test
+  fun `serialize, null`(): Unit = runTest {
+    mapper.kairoWrite(MyClass(null)).shouldBe("{}")
+  }
+
+  @Test
   fun `deserialize, present`(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": 42 }").shouldBe(MyClass(Optional.of(42)))
   }
@@ -53,29 +57,6 @@ internal class OptionalDefaultObjectMapperTest {
 
   @Test
   fun `deserialize, missing`(): Unit = runTest {
-    serializationShouldFail {
-      mapper.readValue<MyClass>("{}")
-    }
-  }
-
-  @Test
-  fun `deserialize, wrong type, float`(): Unit = runTest {
-    serializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\": 1.23 }")
-    }
-  }
-
-  @Test
-  fun `deserialize, wrong type, string`(): Unit = runTest {
-    serializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\": \"42\" }")
-    }
-  }
-
-  @Test
-  fun `deserialize, wrong type, boolean`(): Unit = runTest {
-    serializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\": true }")
-    }
+    mapper.readValue<MyClass>("{}").shouldBe(MyClass(null))
   }
 }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/jvm/ValueClassDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/jvm/ValueClassDefaultObjectMapperTest.kt
@@ -1,0 +1,74 @@
+package kairo.serialization.module.jvm
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.kotest.matchers.shouldBe
+import kairo.serialization.jsonMapper
+import kairo.serialization.serializationShouldFail
+import kairo.serialization.util.kairoWrite
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * This test is intended to test behaviour strictly related to value class serialization/deserialization.
+ * Therefore, some test cases (such as unknown properties, pretty printing) are not included
+ * since they are not strictly related to value classes.
+ */
+internal class ValueClassDefaultObjectMapperTest {
+  @JvmInline
+  internal value class MyValueClass(val value: Int)
+
+  /**
+   * This test is specifically for non-nullable properties.
+   */
+  internal data class MyClass(
+    val value: MyValueClass,
+  )
+
+  private val mapper: JsonMapper = jsonMapper().build()
+
+  @Test
+  fun serialize(): Unit = runTest {
+    mapper.kairoWrite(MyClass(MyValueClass(42))).shouldBe("{\"value\":42}")
+  }
+
+  @Test
+  fun deserialize(): Unit = runTest {
+    mapper.readValue<MyClass>("{ \"value\": 42 }").shouldBe(MyClass(MyValueClass(42)))
+  }
+
+  @Test
+  fun `deserialize, null`(): Unit = runTest {
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": null }")
+    }
+  }
+
+  @Test
+  fun `deserialize, missing`(): Unit = runTest {
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{}")
+    }
+  }
+
+  @Test
+  fun `deserialize, wrong type, float`(): Unit = runTest {
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": 1.23 }")
+    }
+  }
+
+  @Test
+  fun `deserialize, wrong type, string`(): Unit = runTest {
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": \"42\" }")
+    }
+  }
+
+  @Test
+  fun `deserialize, wrong type, boolean`(): Unit = runTest {
+    serializationShouldFail {
+      mapper.readValue<MyClass>("{ \"value\": true }")
+    }
+  }
+}

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/jvm/ValueClassNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/jvm/ValueClassNullableObjectMapperTest.kt
@@ -18,7 +18,7 @@ internal class ValueClassNullableObjectMapperTest {
   internal value class MyValueClass(val value: Int)
 
   /**
-   * This test is specifically for non-nullable properties.
+   * This test is specifically for nullable properties.
    */
   internal data class MyClass(
     val value: MyValueClass?,

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/jvm/ValueClassNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/jvm/ValueClassNullableObjectMapperTest.kt
@@ -1,0 +1,53 @@
+package kairo.serialization.module.jvm
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.kotest.matchers.shouldBe
+import kairo.serialization.jsonMapper
+import kairo.serialization.util.kairoWrite
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * This test is intended to test behaviour strictly related to value class serialization/deserialization.
+ * Therefore, some test cases (such as unknown properties, pretty printing) are not included
+ * since they are not strictly related to value classes.
+ */
+internal class ValueClassNullableObjectMapperTest {
+  @JvmInline
+  internal value class MyValueClass(val value: Int)
+
+  /**
+   * This test is specifically for non-nullable properties.
+   */
+  internal data class MyClass(
+    val value: MyValueClass?,
+  )
+
+  private val mapper: JsonMapper = jsonMapper().build()
+
+  @Test
+  fun serialize(): Unit = runTest {
+    mapper.kairoWrite(MyClass(MyValueClass(42))).shouldBe("{\"value\":42}")
+  }
+
+  @Test
+  fun `serialize, null`(): Unit = runTest {
+    mapper.kairoWrite(MyClass(null)).shouldBe("{\"value\":null}")
+  }
+
+  @Test
+  fun deserialize(): Unit = runTest {
+    mapper.readValue<MyClass>("{ \"value\": 42 }").shouldBe(MyClass(MyValueClass(42)))
+  }
+
+  @Test
+  fun `deserialize, null`(): Unit = runTest {
+    mapper.readValue<MyClass>("{ \"value\": null }").shouldBe(MyClass(null))
+  }
+
+  @Test
+  fun `deserialize, missing`(): Unit = runTest {
+    mapper.readValue<MyClass>("{}").shouldBe(MyClass(null))
+  }
+}

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/ktor/ContentTypeDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/ktor/ContentTypeDefaultObjectMapperTest.kt
@@ -26,13 +26,13 @@ internal class ContentTypeDefaultObjectMapperTest {
   private val mapper: JsonMapper = jsonMapper().build()
 
   @Test
-  fun `serialize, default`(): Unit = runTest {
+  fun serialize(): Unit = runTest {
     mapper.kairoWrite(MyClass(ContentType.Application.Json))
       .shouldBe("{\"value\":\"application/json\"}")
   }
 
   @Test
-  fun `deserialize, default`(): Unit = runTest {
+  fun deserialize(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"application/json\" }")
       .shouldBe(MyClass(ContentType.Application.Json))
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/ktor/ContentTypeDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/ktor/ContentTypeDefaultObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.ktor
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import io.ktor.http.ContentType
 import kairo.serialization.jsonMapper

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/ktor/ContentTypeNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/ktor/ContentTypeNullableObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.ktor
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import io.ktor.http.ContentType
 import kairo.serialization.jsonMapper

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/ktor/ContentTypeNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/ktor/ContentTypeNullableObjectMapperTest.kt
@@ -25,7 +25,7 @@ internal class ContentTypeNullableObjectMapperTest {
   private val mapper: JsonMapper = jsonMapper().build()
 
   @Test
-  fun `serialize, default`(): Unit = runTest {
+  fun serialize(): Unit = runTest {
     mapper.kairoWrite(MyClass(ContentType.Application.Json))
       .shouldBe("{\"value\":\"application/json\"}")
   }
@@ -37,7 +37,7 @@ internal class ContentTypeNullableObjectMapperTest {
   }
 
   @Test
-  fun `deserialize, default`(): Unit = runTest {
+  fun deserialize(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"application/json\" }")
       .shouldBe(MyClass(ContentType.Application.Json))
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/ktor/HttpMethodDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/ktor/HttpMethodDefaultObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.ktor
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import io.ktor.http.HttpMethod
 import kairo.serialization.jsonMapper

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/ktor/HttpMethodNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/ktor/HttpMethodNullableObjectMapperTest.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import io.ktor.http.HttpMethod
 import kairo.serialization.jsonMapper
-import kairo.serialization.serializationShouldFail
 import kairo.serialization.util.kairoWrite
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
@@ -15,12 +14,12 @@ import org.junit.jupiter.api.Test
  * Therefore, some test cases (such as unknown properties, pretty printing) are not included
  * since they are not strictly related to HTTP methods.
  */
-internal class HttpMethodDefaultObjectMapperTest {
+internal class HttpMethodNullableObjectMapperTest {
   /**
-   * This test is specifically for non-nullable properties.
+   * This test is specifically for nullable properties.
    */
   internal data class MyClass(
-    val value: HttpMethod,
+    val value: HttpMethod?,
   )
 
   private val mapper: JsonMapper = jsonMapper().build()
@@ -32,6 +31,12 @@ internal class HttpMethodDefaultObjectMapperTest {
   }
 
   @Test
+  fun `serialize, null`(): Unit = runTest {
+    mapper.kairoWrite(MyClass(null))
+      .shouldBe("{\"value\":null}")
+  }
+
+  @Test
   fun deserialize(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"GET\" }")
       .shouldBe(MyClass(HttpMethod.Get))
@@ -39,22 +44,13 @@ internal class HttpMethodDefaultObjectMapperTest {
 
   @Test
   fun `deserialize, null`(): Unit = runTest {
-    serializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\": null }")
-    }
+    mapper.readValue<MyClass>("{ \"value\": null }")
+      .shouldBe(MyClass(null))
   }
 
   @Test
   fun `deserialize, missing`(): Unit = runTest {
-    serializationShouldFail {
-      mapper.readValue<MyClass>("{}")
-    }
-  }
-
-  @Test
-  fun `deserialize, lowercase`(): Unit = runTest {
-    serializationShouldFail {
-      mapper.readValue<MyClass>("{ \"value\": \"get\" }")
-    }
+    mapper.readValue<MyClass>("{}")
+      .shouldBe(MyClass(null))
   }
 }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/money/DefaultMoneyFormatterTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/money/DefaultMoneyFormatterTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.money
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.util.kairoWrite

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/money/MoneyDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/money/MoneyDefaultObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.money
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.serializationShouldFail

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/money/MoneyNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/money/MoneyNullableObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.money
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.util.kairoWrite

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/BooleanDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/BooleanDefaultObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.primitives
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.serializationShouldFail

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/BooleanIsObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/BooleanIsObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.primitives
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.serializationShouldFail

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/BooleanKeyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/BooleanKeyObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.primitives
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.serializationShouldFail

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/BooleanNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/BooleanNullableObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.primitives
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.util.kairoWrite

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/DoubleDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/DoubleDefaultObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.primitives
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.serializationShouldFail

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/DoubleKeyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/DoubleKeyObjectMapperTest.kt
@@ -22,7 +22,7 @@ internal class DoubleKeyObjectMapperTest {
   private val mapper: JsonMapper = jsonMapper().build()
 
   @Test
-  fun `serialize, default`(): Unit = runTest {
+  fun serialize(): Unit = runTest {
     mapper.kairoWrite(MyClass(mapOf(1.23 to "value")))
       .shouldBe("{\"values\":{\"1.23\":\"value\"}}")
   }
@@ -35,7 +35,7 @@ internal class DoubleKeyObjectMapperTest {
   }
 
   @Test
-  fun `deserialize, default`(): Unit = runTest {
+  fun deserialize(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"values\": { \"1.23\": \"value\" } }")
       .shouldBe(MyClass(mapOf(1.23 to "value")))
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/DoubleKeyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/DoubleKeyObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.primitives
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.serializationShouldFail

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/DoubleNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/DoubleNullableObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.primitives
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.util.kairoWrite

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/FloatDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/FloatDefaultObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.primitives
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.serializationShouldFail

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/FloatKeyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/FloatKeyObjectMapperTest.kt
@@ -22,7 +22,7 @@ internal class FloatKeyObjectMapperTest {
   private val mapper: JsonMapper = jsonMapper().build()
 
   @Test
-  fun `serialize, default`(): Unit = runTest {
+  fun serialize(): Unit = runTest {
     mapper.kairoWrite(MyClass(mapOf(1.23F to "value")))
       .shouldBe("{\"values\":{\"1.23\":\"value\"}}")
   }
@@ -35,7 +35,7 @@ internal class FloatKeyObjectMapperTest {
   }
 
   @Test
-  fun `deserialize, default`(): Unit = runTest {
+  fun deserialize(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"values\": { \"1.23\": \"value\" } }")
       .shouldBe(MyClass(mapOf(1.23F to "value")))
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/FloatKeyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/FloatKeyObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.primitives
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.serializationShouldFail

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/FloatNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/FloatNullableObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.primitives
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.util.kairoWrite

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/IntDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/IntDefaultObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.primitives
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.serializationShouldFail

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/IntKeyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/IntKeyObjectMapperTest.kt
@@ -22,7 +22,7 @@ internal class IntKeyObjectMapperTest {
   private val mapper: JsonMapper = jsonMapper().build()
 
   @Test
-  fun `serialize, default`(): Unit = runTest {
+  fun serialize(): Unit = runTest {
     mapper.kairoWrite(MyClass(mapOf(42 to "value")))
       .shouldBe("{\"values\":{\"42\":\"value\"}}")
   }
@@ -35,7 +35,7 @@ internal class IntKeyObjectMapperTest {
   }
 
   @Test
-  fun `deserialize, default`(): Unit = runTest {
+  fun deserialize(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"values\": { \"42\": \"value\" } }")
       .shouldBe(MyClass(mapOf(42 to "value")))
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/IntKeyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/IntKeyObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.primitives
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.serializationShouldFail

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/IntNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/IntNullableObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.primitives
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.util.kairoWrite

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/LongDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/LongDefaultObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.primitives
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.serializationShouldFail

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/LongKeyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/LongKeyObjectMapperTest.kt
@@ -22,7 +22,7 @@ internal class LongKeyObjectMapperTest {
   private val mapper: JsonMapper = jsonMapper().build()
 
   @Test
-  fun `serialize, default`(): Unit = runTest {
+  fun serialize(): Unit = runTest {
     mapper.kairoWrite(MyClass(mapOf(42L to "value")))
       .shouldBe("{\"values\":{\"42\":\"value\"}}")
   }
@@ -35,7 +35,7 @@ internal class LongKeyObjectMapperTest {
   }
 
   @Test
-  fun `deserialize, default`(): Unit = runTest {
+  fun deserialize(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"values\": { \"42\": \"value\" } }")
       .shouldBe(MyClass(mapOf(42L to "value")))
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/LongKeyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/LongKeyObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.primitives
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.serializationShouldFail

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/LongNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/LongNullableObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.primitives
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.util.kairoWrite

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/StringDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/StringDefaultObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.primitives
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.serializationShouldFail

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/StringKeyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/StringKeyObjectMapperTest.kt
@@ -22,7 +22,7 @@ internal class StringKeyObjectMapperTest {
   private val mapper: JsonMapper = jsonMapper().build()
 
   @Test
-  fun `serialize, default`(): Unit = runTest {
+  fun serialize(): Unit = runTest {
     mapper.kairoWrite(MyClass(mapOf("key" to "value")))
       .shouldBe("{\"values\":{\"key\":\"value\"}}")
   }
@@ -35,7 +35,7 @@ internal class StringKeyObjectMapperTest {
   }
 
   @Test
-  fun `deserialize, default`(): Unit = runTest {
+  fun deserialize(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"values\": { \"key\": \"value\" } }")
       .shouldBe(MyClass(mapOf("key" to "value")))
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/StringKeyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/StringKeyObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.primitives
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.serializationShouldFail

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/StringNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/StringNullableObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.primitives
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.util.kairoWrite

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/StringTrimWhitespaceObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/StringTrimWhitespaceObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.primitives
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kotlinx.coroutines.test.runTest

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/UuidDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/UuidDefaultObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.primitives
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.serializationShouldFail

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/UuidDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/UuidDefaultObjectMapperTest.kt
@@ -26,13 +26,13 @@ internal class UuidDefaultObjectMapperTest {
   private val mapper: JsonMapper = jsonMapper().build()
 
   @Test
-  fun `serialize, default`(): Unit = runTest {
+  fun serialize(): Unit = runTest {
     mapper.kairoWrite(MyClass(Uuid.parse("3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8")))
       .shouldBe("{\"value\":\"3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8\"}")
   }
 
   @Test
-  fun `deserialize, default`(): Unit = runTest {
+  fun deserialize(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8\" }")
       .shouldBe(MyClass(Uuid.parse("3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8")))
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/UuidKeyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/UuidKeyObjectMapperTest.kt
@@ -23,7 +23,7 @@ internal class UuidKeyObjectMapperTest {
   private val mapper: JsonMapper = jsonMapper().build()
 
   @Test
-  fun `serialize, default`(): Unit = runTest {
+  fun serialize(): Unit = runTest {
     mapper.kairoWrite(MyClass(mapOf(Uuid.parse("3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8") to "value")))
       .shouldBe("{\"values\":{\"3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8\":\"value\"}}")
   }
@@ -36,7 +36,7 @@ internal class UuidKeyObjectMapperTest {
   }
 
   @Test
-  fun `deserialize, default`(): Unit = runTest {
+  fun deserialize(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"values\": { \"3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8\": \"value\" } }")
       .shouldBe(MyClass(mapOf(Uuid.parse("3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8") to "value")))
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/UuidKeyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/UuidKeyObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.primitives
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.serializationShouldFail

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/UuidNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/UuidNullableObjectMapperTest.kt
@@ -25,7 +25,7 @@ internal class UuidNullableObjectMapperTest {
   private val mapper: JsonMapper = jsonMapper().build()
 
   @Test
-  fun `serialize, default`(): Unit = runTest {
+  fun serialize(): Unit = runTest {
     mapper.kairoWrite(MyClass(Uuid.parse("3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8")))
       .shouldBe("{\"value\":\"3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8\"}")
   }
@@ -37,7 +37,7 @@ internal class UuidNullableObjectMapperTest {
   }
 
   @Test
-  fun `deserialize, default`(): Unit = runTest {
+  fun deserialize(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"value\": \"3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8\" }")
       .shouldBe(MyClass(Uuid.parse("3ec0a853-dae3-4ee1-abe2-0b9c7dee45f8")))
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/UuidNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/primitives/UuidNullableObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.primitives
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import kairo.serialization.jsonMapper
 import kairo.serialization.util.kairoWrite

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/InstantDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/InstantDefaultObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.time
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.Instant
 import kairo.serialization.jsonMapper

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/InstantKeyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/InstantKeyObjectMapperTest.kt
@@ -23,7 +23,7 @@ internal class InstantKeyObjectMapperTest {
   private val mapper: JsonMapper = jsonMapper().build()
 
   @Test
-  fun `serialize, default`(): Unit = runTest {
+  fun serialize(): Unit = runTest {
     mapper.kairoWrite(MyClass(mapOf(Instant.parse("2023-11-13T19:44:32.123456789Z") to "value")))
       .shouldBe("{\"values\":{\"2023-11-13T19:44:32.123456789Z\":\"value\"}}")
   }
@@ -36,7 +36,7 @@ internal class InstantKeyObjectMapperTest {
   }
 
   @Test
-  fun `deserialize, default`(): Unit = runTest {
+  fun deserialize(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"values\": { \"2023-11-13T19:44:32.123456789Z\": \"value\" } }")
       .shouldBe(MyClass(mapOf(Instant.parse("2023-11-13T19:44:32.123456789Z") to "value")))
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/InstantKeyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/InstantKeyObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.time
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.Instant
 import kairo.serialization.jsonMapper

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/InstantNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/InstantNullableObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.time
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.Instant
 import kairo.serialization.jsonMapper

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/LocalDateDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/LocalDateDefaultObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.time
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.LocalDate
 import kairo.serialization.jsonMapper

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/LocalDateKeyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/LocalDateKeyObjectMapperTest.kt
@@ -23,7 +23,7 @@ internal class LocalDateKeyObjectMapperTest {
   private val mapper: JsonMapper = jsonMapper().build()
 
   @Test
-  fun `serialize, default`(): Unit = runTest {
+  fun serialize(): Unit = runTest {
     mapper.kairoWrite(MyClass(mapOf(LocalDate.parse("2023-11-13") to "value")))
       .shouldBe("{\"values\":{\"2023-11-13\":\"value\"}}")
   }
@@ -36,7 +36,7 @@ internal class LocalDateKeyObjectMapperTest {
   }
 
   @Test
-  fun `deserialize, default`(): Unit = runTest {
+  fun deserialize(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"values\": { \"2023-11-13\": \"value\" } }")
       .shouldBe(MyClass(mapOf(LocalDate.parse("2023-11-13") to "value")))
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/LocalDateKeyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/LocalDateKeyObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.time
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.LocalDate
 import kairo.serialization.jsonMapper

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/LocalDateNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/LocalDateNullableObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.time
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.LocalDate
 import kairo.serialization.jsonMapper

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/YearDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/YearDefaultObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.time
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.Year
 import kairo.serialization.jsonMapper

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/YearKeyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/YearKeyObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.time
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.Year
 import kairo.serialization.jsonMapper

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/YearKeyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/YearKeyObjectMapperTest.kt
@@ -23,7 +23,7 @@ internal class YearKeyObjectMapperTest {
   private val mapper: JsonMapper = jsonMapper().build()
 
   @Test
-  fun `serialize, default`(): Unit = runTest {
+  fun serialize(): Unit = runTest {
     mapper.kairoWrite(MyClass(mapOf(Year.parse("2023") to "value")))
       .shouldBe("{\"values\":{\"2023\":\"value\"}}")
   }
@@ -36,7 +36,7 @@ internal class YearKeyObjectMapperTest {
   }
 
   @Test
-  fun `deserialize, default`(): Unit = runTest {
+  fun deserialize(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"values\": { \"2023\": \"value\" } }")
       .shouldBe(MyClass(mapOf(Year.parse("2023") to "value")))
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/YearMonthDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/YearMonthDefaultObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.time
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.YearMonth
 import kairo.serialization.jsonMapper

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/YearMonthKeyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/YearMonthKeyObjectMapperTest.kt
@@ -23,7 +23,7 @@ internal class YearMonthKeyObjectMapperTest {
   private val mapper: JsonMapper = jsonMapper().build()
 
   @Test
-  fun `serialize, default`(): Unit = runTest {
+  fun serialize(): Unit = runTest {
     mapper.kairoWrite(MyClass(mapOf(YearMonth.parse("2023-11") to "value")))
       .shouldBe("{\"values\":{\"2023-11\":\"value\"}}")
   }
@@ -36,7 +36,7 @@ internal class YearMonthKeyObjectMapperTest {
   }
 
   @Test
-  fun `deserialize, default`(): Unit = runTest {
+  fun deserialize(): Unit = runTest {
     mapper.readValue<MyClass>("{ \"values\": { \"2023-11\": \"value\" } }")
       .shouldBe(MyClass(mapOf(YearMonth.parse("2023-11") to "value")))
   }

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/YearMonthKeyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/YearMonthKeyObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.time
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.YearMonth
 import kairo.serialization.jsonMapper

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/YearMonthNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/YearMonthNullableObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.time
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.YearMonth
 import kairo.serialization.jsonMapper

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/YearNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/YearNullableObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.time
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.Year
 import kairo.serialization.jsonMapper

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/ZoneIdDefaultObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/ZoneIdDefaultObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.time
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.ZoneId
 import java.time.ZoneOffset

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/ZoneIdKeyObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/ZoneIdKeyObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.time
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.ZoneId
 import java.time.ZoneOffset

--- a/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/ZoneIdNullableObjectMapperTest.kt
+++ b/kairo-serialization/src/test/kotlin/kairo/serialization/module/time/ZoneIdNullableObjectMapperTest.kt
@@ -1,7 +1,7 @@
 package kairo.serialization.module.time
 
 import com.fasterxml.jackson.databind.json.JsonMapper
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import java.time.ZoneId
 import java.time.ZoneOffset

--- a/kairo-sql-feature/src/main/kotlin/kairo/sql/plugin/kairo/JsonNodeColumnMapper.kt
+++ b/kairo-sql-feature/src/main/kotlin/kairo/sql/plugin/kairo/JsonNodeColumnMapper.kt
@@ -1,7 +1,7 @@
 package kairo.sql.plugin.kairo
 
 import com.fasterxml.jackson.databind.JsonNode
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import java.sql.ResultSet
 import kairo.sql.sqlMapper
 import org.jdbi.v3.core.mapper.ColumnMapper

--- a/kairo-sql-feature/src/main/kotlin/kairo/sql/plugin/kairo/MoneyColumnMapper.kt
+++ b/kairo-sql-feature/src/main/kotlin/kairo/sql/plugin/kairo/MoneyColumnMapper.kt
@@ -1,6 +1,6 @@
 package kairo.sql.plugin.kairo
 
-import io.github.projectmapk.jackson.module.kogera.readValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import java.sql.ResultSet
 import kairo.sql.sqlMapper
 import org.javamoney.moneta.Money


### PR DESCRIPTION
We were previously on an experimental fork of Jackson while waiting for some Kotlin-related Jackson features to be released in 2.19. That release happened at the end of last week, so we can now upgrade!

Resolves #510.

https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.19