### PR TITLE
Attempt to support more permissive JDBI Jackson reads

### DIFF
--- a/kairo-sql-feature/src/main/kotlin/kairo/sql/plugin/jackson/JacksonPlugin.kt
+++ b/kairo-sql-feature/src/main/kotlin/kairo/sql/plugin/jackson/JacksonPlugin.kt
@@ -1,13 +1,24 @@
 package kairo.sql.plugin.jackson
 
-import kairo.sql.sqlMapper
+import kairo.sql.sqlReadMapper
+import kairo.sql.sqlWriteMapper
+import kotlin.jvm.java
 import org.jdbi.v3.core.Handle
-import org.jdbi.v3.jackson2.Jackson2Config
-import org.jdbi.v3.jackson2.Jackson2Plugin
+import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.spi.JdbiPlugin
+import org.jdbi.v3.json.JsonConfig
+import org.jdbi.v3.json.JsonPlugin
 
-internal class JacksonPlugin : Jackson2Plugin() {
+internal class JacksonPlugin : JdbiPlugin.Singleton() {
+  override fun customizeJdbi(jdbi: Jdbi) {
+    jdbi.installPlugin(JsonPlugin())
+    jdbi.getConfig(JsonConfig::class.java)
+      .setJsonMapper(KairoJacksonJsonMapper())
+  }
+
   override fun customizeHandle(handle: Handle): Handle =
     super.customizeHandle(handle).apply {
-      getConfig(Jackson2Config::class.java).mapper = sqlMapper
+      getConfig(KairoJacksonJdbiConfig::class.java).readMapper = sqlReadMapper
+      getConfig(KairoJacksonJdbiConfig::class.java).writeMapper = sqlWriteMapper
     }
 }

--- a/kairo-sql-feature/src/main/kotlin/kairo/sql/plugin/jackson/KairoJacksonJdbiConfig.kt
+++ b/kairo-sql-feature/src/main/kotlin/kairo/sql/plugin/jackson/KairoJacksonJdbiConfig.kt
@@ -1,0 +1,13 @@
+package kairo.sql.plugin.jackson
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.jdbi.v3.core.config.JdbiConfig
+
+public class KairoJacksonJdbiConfig(
+  public var readMapper: ObjectMapper = ObjectMapper(),
+  public var writeMapper: ObjectMapper = ObjectMapper(),
+) : JdbiConfig<KairoJacksonJdbiConfig> {
+  override fun createCopy(): KairoJacksonJdbiConfig? {
+    return KairoJacksonJdbiConfig(readMapper, writeMapper)
+  }
+}

--- a/kairo-sql-feature/src/main/kotlin/kairo/sql/plugin/jackson/KairoJacksonJsonMapper.kt
+++ b/kairo-sql-feature/src/main/kotlin/kairo/sql/plugin/jackson/KairoJacksonJsonMapper.kt
@@ -1,0 +1,76 @@
+package kairo.sql.plugin.jackson
+
+import org.jdbi.v3.jackson2.Jackson2Config
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.JavaType
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.ObjectReader
+import com.fasterxml.jackson.databind.ObjectWriter
+import org.jdbi.v3.core.config.ConfigRegistry
+import org.jdbi.v3.core.result.UnableToProduceResultException
+import org.jdbi.v3.json.JsonMapper
+import java.io.IOException
+import java.lang.reflect.Type
+import kotlin.jvm.java
+
+/**
+ * Forked from JDBI's JacksonJsonMapper.
+ *
+ * This is identical to the JDBI version, except that it uses a separate read and write mappers
+ * via KairoJacksonJdbiConfig.
+ *
+ * JDBI license note:
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+internal class KairoJacksonJsonMapper : JsonMapper {
+  override fun forType(type: Type, config: ConfigRegistry): JsonMapper.TypedJsonMapper {
+    return object : JsonMapper.TypedJsonMapper {
+      private val writeMapper: ObjectMapper = config.get(KairoJacksonJdbiConfig::class.java).writeMapper
+      private val readMapper: ObjectMapper = config.get(KairoJacksonJdbiConfig::class.java).readMapper
+      private val writeMappedType: JavaType = writeMapper.constructType(type)
+      private val readMappedType: JavaType = readMapper.constructType(type)
+      private val reader: ObjectReader = readMapper.readerFor(readMappedType)
+      private val writer: ObjectWriter = writeMapper.writerFor(writeMappedType)
+
+      override fun toJson(value: Any?, config: ConfigRegistry): String? {
+        val view: Class<*>? = config.get(Jackson2Config::class.java).serializationView
+        val viewWriter: ObjectWriter =
+          if (view == null)
+            writer
+          else
+            writer.withView(view)
+        try {
+          return viewWriter.writeValueAsString(value)
+        } catch (e: JsonProcessingException) {
+          throw UnableToProduceResultException(e)
+        }
+      }
+
+      override fun fromJson(json: String, config: ConfigRegistry): Any? {
+        val view: Class<*>? = config.get(Jackson2Config::class.java).deserializationView
+        val viewReader: ObjectReader =
+          if (view == null)
+            reader
+          else
+            reader.withView(view)
+        try {
+          return viewReader.readValue(json)
+        } catch (e: IOException) {
+          throw UnableToProduceResultException(e)
+        }
+      }
+    }
+  }
+}

--- a/kairo-sql-feature/src/main/kotlin/kairo/sql/plugin/kairo/JsonNodeArgumentFactory.kt
+++ b/kairo-sql-feature/src/main/kotlin/kairo/sql/plugin/kairo/JsonNodeArgumentFactory.kt
@@ -3,7 +3,7 @@ package kairo.sql.plugin.kairo
 import com.fasterxml.jackson.databind.JsonNode
 import java.sql.Types
 import kairo.serialization.util.kairoWrite
-import kairo.sql.sqlMapper
+import kairo.sql.sqlWriteMapper
 import org.jdbi.v3.core.argument.AbstractArgumentFactory
 import org.jdbi.v3.core.argument.Argument
 import org.jdbi.v3.core.config.ConfigRegistry
@@ -14,7 +14,7 @@ public class JsonNodeArgumentFactory : AbstractArgumentFactory<JsonNode>(Types.O
     Argument { position, statement, _ ->
       val pgObject = PGobject().apply {
         type = "jsonb"
-        setValue(sqlMapper.kairoWrite(value))
+        setValue(sqlWriteMapper.kairoWrite(value))
       }
       statement.setObject(position, pgObject)
     }

--- a/kairo-sql-feature/src/main/kotlin/kairo/sql/plugin/kairo/JsonNodeColumnMapper.kt
+++ b/kairo-sql-feature/src/main/kotlin/kairo/sql/plugin/kairo/JsonNodeColumnMapper.kt
@@ -1,15 +1,17 @@
 package kairo.sql.plugin.kairo
 
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import java.sql.ResultSet
-import kairo.sql.sqlMapper
+import kairo.sql.sqlReadMapper
+import kairo.sql.sqlWriteMapper
 import org.jdbi.v3.core.mapper.ColumnMapper
 import org.jdbi.v3.core.statement.StatementContext
 
 public class JsonNodeColumnMapper : ColumnMapper<JsonNode> {
   override fun map(r: ResultSet, columnNumber: Int, ctx: StatementContext): JsonNode? {
     val string = r.getString(columnNumber) ?: return null
-    return sqlMapper.readValue(string)
+    return sqlReadMapper.readValue(string)
   }
 }

--- a/kairo-sql-feature/src/main/kotlin/kairo/sql/plugin/kairo/MoneyArgumentFactory.kt
+++ b/kairo-sql-feature/src/main/kotlin/kairo/sql/plugin/kairo/MoneyArgumentFactory.kt
@@ -2,7 +2,7 @@ package kairo.sql.plugin.kairo
 
 import java.sql.Types
 import kairo.serialization.util.kairoWrite
-import kairo.sql.sqlMapper
+import kairo.sql.sqlWriteMapper
 import org.javamoney.moneta.Money
 import org.jdbi.v3.core.argument.AbstractArgumentFactory
 import org.jdbi.v3.core.argument.Argument
@@ -14,7 +14,7 @@ public class MoneyArgumentFactory : AbstractArgumentFactory<Money>(Types.OTHER) 
     Argument { position, statement, _ ->
       val pgObject = PGobject().apply {
         type = "jsonb"
-        setValue(sqlMapper.kairoWrite(value))
+        setValue(sqlWriteMapper.kairoWrite(value))
       }
       statement.setObject(position, pgObject)
     }

--- a/kairo-sql-feature/src/main/kotlin/kairo/sql/plugin/kairo/MoneyColumnMapper.kt
+++ b/kairo-sql-feature/src/main/kotlin/kairo/sql/plugin/kairo/MoneyColumnMapper.kt
@@ -2,7 +2,7 @@ package kairo.sql.plugin.kairo
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import java.sql.ResultSet
-import kairo.sql.sqlMapper
+import kairo.sql.sqlReadMapper
 import org.javamoney.moneta.Money
 import org.jdbi.v3.core.mapper.ColumnMapper
 import org.jdbi.v3.core.statement.StatementContext
@@ -10,6 +10,6 @@ import org.jdbi.v3.core.statement.StatementContext
 public class MoneyColumnMapper : ColumnMapper<Money> {
   override fun map(r: ResultSet, columnNumber: Int, ctx: StatementContext): Money? {
     val string = r.getString(columnNumber) ?: return null
-    return sqlMapper.readValue(string)
+    return sqlReadMapper.readValue(string)
   }
 }

--- a/kairo-sql-feature/src/main/kotlin/kairo/sql/sqlMapper.kt
+++ b/kairo-sql-feature/src/main/kotlin/kairo/sql/sqlMapper.kt
@@ -1,10 +1,20 @@
 package kairo.sql
 
+import com.fasterxml.jackson.databind.MapperFeature
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.json.JsonMapper
 import kairo.serialization.jsonMapper
 import kairo.serialization.property.allowUnknownProperties
 
-public val sqlMapper: JsonMapper =
+public val sqlReadMapper: JsonMapper =
+  jsonMapper {
+    allowUnknownProperties = true
+  }.build {
+    propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+    enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
+  }
+
+public val sqlWriteMapper: JsonMapper =
   jsonMapper {
     allowUnknownProperties = true
   }.build()


### PR DESCRIPTION
This *ALMOST* works. I was able to split out the reader and writer by forking the Jackson / JDBI plugin. Unfortunately this still isn't fully backward compatible because when reading `jsonb -> JsonNode` properties, Jackson is actually applying the snake_case transformation to the json, so we can't just merge this.