### PR TITLE
Upgrade Gradle to 9.1.0

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### Description

https://github.com/hudson155/kairo/issues/941

https://docs.gradle.org/9.1.0/release-notes.html#build-initialization-uses-the-kotlin-test-dependency-for-kotlin-projects

### Checklist

#### Documentation

- [x] KDoc
- [x] Feature README
- [x] Root README
- [x] BOMs
- [x] Changelog

#### Externalities

- [x] Dependencies
- [x] Issues
- [x] Sample repo

#### Tests

- [x] Tests
