### PR TITLE
Switch CI branch to main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,12 +6,10 @@ permissions:
 on:
   pull_request:
     branches:
-      - "kairo-5"
-      - "kairo-6"
+      - "main"
   push:
     branches:
-      - "kairo-5"
-      - "kairo-6"
+      - "main"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
### Description

With the v6.0.0-beta.1 release, the branch name has changed from `kairo-6` to `main`.

### Checklist

#### Documentation

- [x] KDoc
- [x] Feature README
- [x] Root README
- [x] BOMs
- [x] Changelog

#### Externalities

- [x] Dependencies
- [x] Issues
- [x] Sample repo

#### Tests

- [x] Tests
